### PR TITLE
Wal as Raft Log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,4 @@ client/
 start*.bat
 RpcClient.lua
 temp/*
+*.dll

--- a/npl_mod/Raft/FileBasedServerStateManager.lua
+++ b/npl_mod/Raft/FileBasedServerStateManager.lua
@@ -91,7 +91,7 @@ end
 
 
 function FileBasedServerStateManager:persistState(serverState)
-    self.logger.trace("FileBasedServerStateManager:persistState>term:%f,commitIndex:%f,votedFor:%f", 
+    self.logger.trace("persistState>term:%f,commitIndex:%f,votedFor:%f", 
                         serverState.term, serverState.commitIndex, serverState.votedFor)
     self.serverStateFile:WriteDouble(serverState.term)
     self.serverStateFile:WriteDouble(serverState.commitIndex)

--- a/npl_mod/Raft/FileBasedServerStateManager.lua
+++ b/npl_mod/Raft/FileBasedServerStateManager.lua
@@ -39,6 +39,8 @@ function FileBasedServerStateManager:new(dataDirectory)
     };
     setmetatable(o, self);
 
+    o.logger.info("started");
+
     local configFile = ParaIO.open(o.container..CONFIG_FILE, "r");
     if configFile:IsValid() then
         local line = configFile:readline()
@@ -108,6 +110,7 @@ function FileBasedServerStateManager:readState()
         self.serverStateFile = ParaIO.open(self.serverStateFileName, "rw");
         assert(self.serverStateFile:IsValid(), "serverStateFile not Valid")
         self.serverStateFile:seek(0)
+        self.logger.info("state file size == 0")
         return;
     end
 

--- a/npl_mod/Raft/FileBasedServerStateManager.lua
+++ b/npl_mod/Raft/FileBasedServerStateManager.lua
@@ -39,7 +39,6 @@ function FileBasedServerStateManager:new(dataDirectory)
     };
     setmetatable(o, self);
 
-    o.logger.info("started");
 
     local configFile = ParaIO.open(o.container..CONFIG_FILE, "r");
     if configFile:IsValid() then
@@ -49,6 +48,7 @@ function FileBasedServerStateManager:new(dataDirectory)
     end
     
     o.serverStateFileName = o.container..STATE_FILE;
+    o.logger.info("started with stateFile:%s", o.serverStateFileName);
     o.serverStateFile = ParaIO.open(o.serverStateFileName, "rw");
     assert(o.serverStateFile:IsValid(), "serverStateFile not Valid")
     o.serverStateFile:seek(0)

--- a/npl_mod/Raft/LogBuffer.lua
+++ b/npl_mod/Raft/LogBuffer.lua
@@ -3,7 +3,7 @@ Title:
 Author: liuluheng
 Date: 2017.03.25
 Desc: 
-the LogBuffer is startIndex based
+    the LogBuffer is startIndex based
 ------------------------------------------------------------
 NPL.load("(gl)npl_mod/Raft/LogBuffer.lua");
 local LogBuffer = commonlib.gettable("Raft.LogBuffer");

--- a/npl_mod/Raft/PeerServer.lua
+++ b/npl_mod/Raft/PeerServer.lua
@@ -103,10 +103,13 @@ function PeerServer:SendRequest(request, callbackFunc)
 		o:slowDownHeartbeating()
 
 		local err = {
-			string = string.format("activate %s from %s failed(%d), err:%s, msg:",
-				destination, source, activate_result or -1, err or "", util.table_tostring(request)),
+			string = string.format("%s->%s failed(%d):%s",
+				source, destination, activate_result or -1, err or ""),
 			request = request
 		}
+		if isAppendRequest then
+			err.string = err.string .. format(",commitIndex:%d", request.commitIndex);
+		end
 
 		if callbackFunc then
 			callbackFunc(msg, err)

--- a/npl_mod/Raft/RaftServer.lua
+++ b/npl_mod/Raft/RaftServer.lua
@@ -40,7 +40,7 @@ NPL.load("(gl)npl_mod/Raft/Rutils.lua");
 local Rutils = commonlib.gettable("Raft.Rutils");
 
 local RaftServer = commonlib.gettable("Raft.RaftServer");
-
+local WALHandlerFile = "RPC/WALHandler.lua";
 
 local DEFAULT_SNAPSHOT_SYNC_BLOCK_SIZE = 4 * 1024;
 
@@ -130,6 +130,11 @@ function RaftServer:new(ctx)
     -- election timer
     o:restartElectionTimer()
     
+    
+    -- register WAL Page handler
+    NPL.this(function()
+        o:handleWALRequest(msg);
+    end, {filename = WALHandlerFile});
     o.logger.info(format("Server %d started", o.id))
     return o;
 end
@@ -231,7 +236,7 @@ function RaftServer:handleAppendEntriesRequest(request)
         self.logger.trace("initial->entry len:%d, index:%d, logIndex:%d", #logEntries, index, logIndex)
         while index < self.logStore:getFirstAvailableIndex() and
             logIndex < #logEntries + 1 --do
-             and
+            and
             logEntries[logIndex].term == self.logStore:getLogEntryAt(index).term do
             logIndex = logIndex + 1;
             index = index + 1;
@@ -250,7 +255,7 @@ function RaftServer:handleAppendEntriesRequest(request)
             
             self.logStore:writeAt(index, logEntries[logIndex]);
             if (logEntry.valueType == LogValueType.Application) then
-                self.stateMachine:preCommit(index, logEntry.value);
+                -- self.stateMachine:preCommit(index, logEntry.value);
             elseif (logEntry.valueType == LogValueType.Configuration) then
                 self.logger.info("received a configuration change at index %d from leader", index);
                 self.configChanging = true;
@@ -270,7 +275,7 @@ function RaftServer:handleAppendEntriesRequest(request)
                 self.logger.info("received a configuration change at index %d from leader", indexForEntry);
                 self.configChanging = true;
             elseif (logEntry.valueType == LogValueType.Application) then
-                self.stateMachine:preCommit(indexForEntry, logEntry.value);
+                -- self.stateMachine:preCommit(indexForEntry, logEntry.value);
             end
         end
     end
@@ -308,6 +313,14 @@ function RaftServer:handleVoteRequest(request)
     return response;
 end
 
+
+function RaftServer:handleWALRequest(request)
+    local logEntry = LogEntry:new(term, request)
+    local logIndex = self.logStore:append(logEntry)
+    self:requestAllAppendEntries();
+end
+
+
 function RaftServer:handleClientRequest(request)
     local response = {
         messageType = RaftMessageType.AppendEntriesResponse,
@@ -323,16 +336,18 @@ function RaftServer:handleClientRequest(request)
     
     local term = self.state.term
     
+    -- the leader executes the SQL, but the followers just append to WAL
     if request.logEntries and #request.logEntries > 0 then
         for i, v in ipairs(request.logEntries) do
-            local logEntry = LogEntry:new(term, v.value)
-            local logIndex = self.logStore:append(logEntry)
+            -- local logEntry = LogEntry:new(term, v.value)
+            -- local logIndex = self.logStore:append(logEntry)
             self.stateMachine:preCommit(logIndex, v.value);
         end
     end
     
-    self:requestAllAppendEntries();
+    -- self:requestAllAppendEntries();
     response.accepted = true;
+    -- nextIndex is not used in RaftClient for now
     response.nextIndex = self.logStore:getFirstAvailableIndex();
     return response
 end
@@ -528,7 +543,7 @@ function RaftServer:handleAppendEntriesResponse(response)
     -- Try to match up the logs for this peer
     if (self.role == ServerRole.Leader and needToCatchup) then
         self.logger.info("server %d needToCatchup %d < %d", peer:getId(), peer.nextLogIndex, self.logStore:getFirstAvailableIndex())
-        -- self:requestAppendEntries(peer);
+    -- self:requestAppendEntries(peer);
     end
 end
 
@@ -574,7 +589,7 @@ function RaftServer:handleInstallSnapshotResponse(response)
             peer.snapshotSyncContext = nil;
         end
         self.logger.info("peer (%d) declines (%d) to install the snapshot (%d), may retry",
-                          peer:getId(), peer.nextLogIndex, self.logStore:getStartIndex());
+            peer:getId(), peer.nextLogIndex, self.logStore:getStartIndex());
     end
     
     -- This may not be a leader anymore, such as the response was sent out long time ago
@@ -810,7 +825,7 @@ function RaftServer:createAppendEntriesRequest(peer)
     local currentNextIndex = self.logStore:getFirstAvailableIndex();
     local commitIndex = self.quickCommitIndex;
     local term = self.state.term;
-
+    
     if (peer.nextLogIndex == 0) then
         peer.nextLogIndex = currentNextIndex;
     end
@@ -999,7 +1014,7 @@ function RaftServer:handleInstallSnapshotRequest(request)
     -- if (snapshotSyncRequest.snapshot.lastLogIndex <= self.quickCommitIndex) then
     if (snapshotSyncRequest.snapshot.lastLogIndex <= self.logStore:getFirstAvailableIndex()) then
         self.logger.error("Received a snapshot (%d) which is older than this (%d) server (%d, %d)",
-                           snapshotSyncRequest.snapshot.lastLogIndex, self.id, self.quickCommitIndex, self.logStore:getFirstAvailableIndex());
+            snapshotSyncRequest.snapshot.lastLogIndex, self.id, self.quickCommitIndex, self.logStore:getFirstAvailableIndex());
         response.nextIndex = self.logStore:getFirstAvailableIndex();
         response.accepted = false;
         return response;
@@ -1523,7 +1538,7 @@ function RaftServer:createSyncSnapshotRequest(peer, lastLogIndex, term, commitIn
     local blockSize = self:getSnapshotSyncBlockSize();
     local expectedSize = (sizeLeft > blockSize and blockSize) or sizeLeft;
     local data = {}
-
+    
     local sizeRead, error = self.stateMachine:readSnapshotData(snapshot, currentCollectionName, offset, data, expectedSize);
     if error then
         -- if there is i/o error, no reason to continue
@@ -1573,9 +1588,9 @@ end
 -- TODO: resemble IOThread in TableDB ? this may cause synchronize issue
 function real_commit(server)
     local currentCommitIndex = server.state.commitIndex;
-    if server.quickCommitIndex <= currentCommitIndex or 
-       currentCommitIndex >= server.logStore:getFirstAvailableIndex() - 1 then
-        return ;
+    if server.quickCommitIndex <= currentCommitIndex or
+        currentCommitIndex >= server.logStore:getFirstAvailableIndex() - 1 then
+        return;
     end
     while (currentCommitIndex < server.quickCommitIndex and currentCommitIndex < server.logStore:getFirstAvailableIndex() - 1) do
         currentCommitIndex = currentCommitIndex + 1;
@@ -1591,7 +1606,11 @@ function real_commit(server)
             -- do nothing
             server.logger.error("committed an empty LogEntry at %d !!", currentCommitIndex)
         elseif (logEntry.valueType == LogValueType.Application) then
-            server.stateMachine:commit(currentCommitIndex, logEntry.value);
+            if server.role ~= ServerRole.Leader then
+                -- only commit follower, leader committed in preCommit
+                server.stateMachine:commit(currentCommitIndex, logEntry.value);
+            end
+        
         elseif (logEntry.valueType == LogValueType.Configuration) then
             local newConfig = ClusterConfiguration:fromBytes(logEntry.value);
             server.logger.info("configuration at index %d is committed", newConfig.logIndex);
@@ -1617,7 +1636,7 @@ end
 
 local function activate()
     if (msg and msg.server) then
-    end
+        end
 end
 
 NPL.this(activate);

--- a/npl_mod/Raft/RaftServer.lua
+++ b/npl_mod/Raft/RaftServer.lua
@@ -437,7 +437,7 @@ end
 
 function RaftServer:requestAllAppendEntries()
     -- be careful with the table and sequence array !
-    self.logger.trace("#self.peers:%d, peers table size:%d", #self.peers, Rutils.table_size(self.peers))
+    -- self.logger.trace("#self.peers:%d, peers table size:%d", #self.peers, Rutils.table_size(self.peers))
     if (Rutils.table_size(self.peers) == 0) then
         self:commit(self.logStore:getFirstAvailableIndex() - 1);
         return;
@@ -524,7 +524,7 @@ function RaftServer:handleAppendEntriesResponse(response)
         -- majority is a float without math.ceil
         -- lua index start form 1
         local majority = math.ceil((Rutils.table_size(self.peers) + 1) / 2);
-        self.logger.trace("total server num:%d, major num:%d", Rutils.table_size(self.peers) + 1, majority)
+        self.logger.trace("total server:%d, major:%d", Rutils.table_size(self.peers) + 1, majority)
         self:commit(matchedIndexes[majority]);
         needToCatchup = peer:clearPendingCommit() or response.nextIndex < self.logStore:getFirstAvailableIndex();
     else

--- a/npl_mod/Raft/Rpc.lua
+++ b/npl_mod/Raft/Rpc.lua
@@ -85,9 +85,19 @@ function Rpc:SetPublicFile(filename)
   filename = filename or format("Rpc/%s.lua", self.fullname);
   self.filename = filename;
 
-  NPL.this(function() 
-    self:OnActivated(msg);
-  end, {filename = self.filename});
+  if self.filename == "RaftRequestRPC" then
+    NPL.this(function() 
+      self:OnActivated(msg);
+    end, {PreemptiveCount = 2000, MsgQueueSize=50000, filename = self.filename});
+  elseif self.filename == "RTDBRequestRPC" then
+    NPL.this(function() 
+      self:OnActivated(msg);
+    end, {PreemptiveCount = 1000, filename = self.filename}); 
+  else
+    NPL.this(function() 
+        self:OnActivated(msg);
+      end, {filename = self.filename});
+  end
 
   self.logger.info("%s installed to file %s", self.fullname, self.filename);
 end

--- a/npl_mod/Raft/Rpc.lua
+++ b/npl_mod/Raft/Rpc.lua
@@ -185,7 +185,7 @@ function Rpc:OnActivated(msg)
         callbackId = msg.callbackId
       }
       -- if type(self.localAddress) == "table" then
-        self.logger.trace("activate on %s, msg:%s", vFileId, util.table_tostring(response))
+        -- self.logger.trace("activate on %s, msg:%s", vFileId, util.table_tostring(response))
       -- end
       local activate_result = NPL.activate(vFileId, response)
 
@@ -295,7 +295,7 @@ function Rpc:activate(localAddress, remoteAddress, msg, callbackFunc, timeout)
     remoteAddress = self.localAddress,
   }
   -- if type(self.localAddress) == "table" then
-    self.logger.trace("activate on %s, msg:%s", vFileId, util.table_tostring(msg))
+    -- self.logger.trace("activate on %s, msg:%s", vFileId, util.table_tostring(msg))
   -- end
   local activate_result = NPL.activate(vFileId, msg);
   -- handle memory leak

--- a/npl_mod/Raft/RpcListener.lua
+++ b/npl_mod/Raft/RpcListener.lua
@@ -70,6 +70,7 @@ function RpcListener:startListening(messageHandler)
 	att:SetField("IdleTimeoutPeriod", 1200000);
     __rts__:SetMsgQueueSize(50000);
     -- port is need to be string here??
+    -- NPL.StartNetServer("0.0.0.0", tostring(self.port));
     NPL.StartNetServer(self.ip, tostring(self.port));
     
     for _, server in ipairs(self.servers) do

--- a/npl_mod/Raft/RpcListener.lua
+++ b/npl_mod/Raft/RpcListener.lua
@@ -61,6 +61,8 @@ function RpcListener:startListening(messageHandler)
         msg = messageHandler:processRequest(msg)
         return msg;
     end)
+    RaftRequestRPC.remoteThread = self.threadName;
+    RaftRequestRPC:MakePublic();
 
 	-- set NPL attributes before starting the server. 
 	local att = NPL.GetAttributeObject();
@@ -77,7 +79,5 @@ function RpcListener:startListening(messageHandler)
         Rutils.initConnect(self.thisServerId, server)
     end
 
-    RaftRequestRPC.remoteThread = self.threadName;
-    RaftRequestRPC:MakePublic();
 
 end

--- a/npl_mod/Raft/RpcListener.lua
+++ b/npl_mod/Raft/RpcListener.lua
@@ -69,9 +69,9 @@ function RpcListener:startListening(messageHandler)
 	att:SetField("IdleTimeout", true);
 	att:SetField("IdleTimeoutPeriod", 1200000);
     __rts__:SetMsgQueueSize(50000);
-    -- port is need to be string here??
+    -- for docker
     -- NPL.StartNetServer("0.0.0.0", tostring(self.port));
-    NPL.StartNetServer(self.ip, tostring(self.port));
+    NPL.StartNetServer(self.ip, self.port);
     
     for _, server in ipairs(self.servers) do
         Rutils.initConnect(self.thisServerId, server)

--- a/npl_mod/Raft/RpcListener.lua
+++ b/npl_mod/Raft/RpcListener.lua
@@ -57,7 +57,7 @@ function RpcListener:startListening(messageHandler)
     -- use Rpc for incoming Request message
     local this = self
     Rpc:new():init("RaftRequestRPC", function(self, msg) 
-        this.logger.trace("RaftRequestRPC:%s",util.table_tostring(msg));
+        -- this.logger.trace("RaftRequestRPC:%s",util.table_tostring(msg));
         msg = messageHandler:processRequest(msg)
         return msg;
     end)

--- a/npl_mod/Raft/RpcListener.lua
+++ b/npl_mod/Raft/RpcListener.lua
@@ -61,6 +61,8 @@ function RpcListener:startListening(messageHandler)
         msg = messageHandler:processRequest(msg)
         return msg;
     end)
+    RaftRequestRPC.remoteThread = self.threadName;
+    RaftRequestRPC:MakePublic();
 
 	-- set NPL attributes before starting the server. 
 	local att = NPL.GetAttributeObject();
@@ -69,14 +71,11 @@ function RpcListener:startListening(messageHandler)
 	att:SetField("IdleTimeout", true);
 	att:SetField("IdleTimeoutPeriod", 1200000);
     __rts__:SetMsgQueueSize(50000);
-    -- port is need to be string here??
-    NPL.StartNetServer(self.ip, tostring(self.port));
+    NPL.StartNetServer(self.ip, self.port);
     
     for _, server in ipairs(self.servers) do
         Rutils.initConnect(self.thisServerId, server)
     end
 
-    RaftRequestRPC.remoteThread = self.threadName;
-    RaftRequestRPC:MakePublic();
 
 end

--- a/npl_mod/Raft/SequentialLogStore.lua
+++ b/npl_mod/Raft/SequentialLogStore.lua
@@ -14,8 +14,7 @@ local SequentialLogStore = commonlib.gettable("Raft.SequentialLogStore");
 ]]--
 NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
 local util = commonlib.gettable("System.Compiler.lib.util")
-NPL.load("(gl)npl_mod/Raft/LogEntry.lua");
-local LogEntry = commonlib.gettable("Raft.LogEntry");
+
 NPL.load("(gl)npl_mod/Raft/LogBuffer.lua");
 local LogBuffer = commonlib.gettable("Raft.LogBuffer");
 
@@ -23,63 +22,17 @@ local LoggerFactory = NPL.load("(gl)npl_mod/Raft/LoggerFactory.lua");
 
 local SequentialLogStore = commonlib.gettable("Raft.SequentialLogStore");
 
-
-local LOG_INDEX_FILE = "store.idx";
-local LOG_STORE_FILE = "store.data";
-local LOG_START_INDEX_FILE = "store.sti";
-local LOG_INDEX_FILE_BAK = "store.idx.bak";
-local LOG_STORE_FILE_BAK = "store.data.bak";
-local LOG_START_INDEX_FILE_BAK = "store.sti.bak";
 local BUFFER_SIZE = 1000;
 
--- NOTE: 
--- we use Double instead of Long at where it should be a Long
--- but is the conversion between double and bytes is correct?
--- it should be
-local DoubleBytes = 8; -- 64 bits
-
-local openFile;
 
 function SequentialLogStore:new(logContainer) 
     local o = {
         logContainer = logContainer,
         logger = LoggerFactory.getLogger("SequentialLogStore"),
-        zeroEntry = LogEntry:new(),
         bufferSize = BUFFER_SIZE,
     };
     setmetatable(o, self);
 
-    o.indexFileName = o.logContainer..LOG_INDEX_FILE
-    o.dataFileName = o.logContainer..LOG_STORE_FILE
-    o.startIndexFileName = o.logContainer..LOG_START_INDEX_FILE
-
-    o.backupIndexFileName = o.logContainer..LOG_INDEX_FILE_BAK
-    o.backupDataFileName = o.logContainer..LOG_STORE_FILE_BAK
-    o.backupStartIndexFileName = o.logContainer..LOG_START_INDEX_FILE_BAK
-
-    openFile(o, "r");
-    local startIndexFileSize = o.startIndexFile:GetFileSize()
-    local indexFileSize = o.indexFile:GetFileSize()
-
-    o.logger.trace("SequentialLogStore:new>startIndexFileSize:%d, indexFileSize:%d", startIndexFileSize, indexFileSize)
-
-    if(startIndexFileSize == 0) then
-        openFile(o, "rw");
-        o.startIndex = 1;
-        o.startIndexFile:WriteDouble(o.startIndex);
-    else
-        o.startIndex = o.startIndexFile:ReadDouble();
-    end
-
-    o.entriesInStore = indexFileSize / DoubleBytes;
-
-    o.buffer = LogBuffer:new((o.entriesInStore > o.bufferSize and (o.entriesInStore + o.startIndex - o.bufferSize)) or o.startIndex, o.bufferSize);
-
-    o:fillBuffer();
-    o.logger.debug("log store started with entriesInStore=%d, startIndex=%d", o.entriesInStore, o.startIndex);
-
-
-    openFile(o, "rw");
     return o;
 end
 
@@ -96,7 +49,6 @@ end
    @return value >= 1
 ]]--
 function SequentialLogStore:getFirstAvailableIndex()
-    return self.entriesInStore + self.startIndex;
 end
 
 --[[
@@ -105,7 +57,6 @@ end
    @return start index of the log store
 ]]--
 function SequentialLogStore:getStartIndex()
-    return self.startIndex
 end
 
 --[[
@@ -113,8 +64,7 @@ end
    @return a dummy constant entry with value set to null and term set to zero if no log entry in store
 ]]--
 function SequentialLogStore:getLastLogEntry()
-    local lastEntry = self.buffer:lastEntry();
-    return (lastEntry == nil and self.zeroEntry) or lastEntry;
+
 end
 
 --[[
@@ -123,19 +73,7 @@ end
    @return the last appended log index
 ]]--
 function SequentialLogStore:append(logEntry)
-    self.indexFile:SetFilePointer(0, 2)
-    self.dataFile:SetFilePointer(0, 2)
-    self.indexFile:WriteDouble(self.dataFile:getpos());
-    -- self.logger.trace("datafile pos:%d, indexfile pos:%d", self.dataFile:getpos(), self.indexFile:getpos())
-    -- self.dataFile:seek(dataFileLength);
-    self.dataFile:WriteDouble(logEntry.term);
-    self.dataFile:WriteBytes(1, {logEntry.valueType});
-    -- self.dataFile:WriteBytes(#logEntry.value, {logEntry.value:byte(1, -1)});
-    self.dataFile:write(logEntry.value, #logEntry.value);
 
-    self.entriesInStore = self.entriesInStore + 1;
-    self.buffer:append(logEntry);
-    return self.entriesInStore + self.startIndex - 1;
 end
 
 --[[
@@ -144,49 +82,7 @@ end
    @param logEntry
 ]]--
 function SequentialLogStore:writeAt(logIndex, logEntry)
-    if logIndex < self.startIndex then
-        return;
-    end
 
-    openFile(self, "r")
-
-    local index = logIndex - self.startIndex
-    -- find the positions for index and data files
-    local dataPosition = self.dataFile:GetFileSize();
-    local indexPosition = (index - 1) * DoubleBytes;
-    if(indexPosition < self.indexFile:GetFileSize()) then
-        self.indexFile:seek(indexPosition);
-        dataPosition = self.indexFile:ReadDouble();
-    end
-
-    local dataFileSize = self.dataFile:GetFileSize();
-    local indexFileSize = self.indexFile:GetFileSize();
-
-    openFile(self, "rw")
-    -- write the data at the specified position
-    self.indexFile:seek(indexPosition);
-    self.dataFile:seek(dataPosition);
-    self.indexFile:WriteDouble(dataPosition);
-    self.dataFile:WriteDouble(logEntry.term);
-    self.dataFile:WriteBytes(1, {logEntry.valueType});
-    -- self.dataFile:WriteBytes(#logEntry.value, {logEntry.value:byte(1, -1)});
-    self.dataFile:write(logEntry.value, #logEntry.value);
-
-    -- trim the files if necessary
-    if(indexFileSize > self.indexFile:getpos()) then
-        self.indexFile:SetEndOfFile();
-    end
-
-    if(dataFileSize > self.dataFile:getpos()) then
-        self.dataFile:SetEndOfFile();
-    end
-
-    if(index <= self.entriesInStore) then
-        self.buffer:trim(logIndex);
-    end
-    
-    self.buffer:append(logEntry);
-    self.entriesInStore = index;
 end
 
 --[[
@@ -196,58 +92,7 @@ end
    @return the log entries between [start, end)
 ]]--
 function SequentialLogStore:getLogEntries(startIndex, endIndex)
-    self.logger.trace("getLogEntries:startIndex:%d, endIndex:%d, self.startIndex:%d, self.entriesInStore:%d",
-                       startIndex, endIndex, self.startIndex, self.entriesInStore)
-    if startIndex < self.startIndex then
-        return;
-    end
 
-    -- start and adjustedEnd are zero based, targetEndIndex is this.startIndex based
-    local start = startIndex - self.startIndex;
-    local adjustedEnd = endIndex - self.startIndex;
-    adjustedEnd = (adjustedEnd > self.entriesInStore and self.entriesInStore) or adjustedEnd;
-    local targetEndIndex = (endIndex > self.entriesInStore + self.startIndex + 1 and self.entriesInStore + self.startIndex + 1) or endIndex;
-
-    local entries = {}
-    if adjustedEnd - start == 0 then
-        return entries
-    end
-
-    self.logger.trace("getLogEntries:pre fill entries len:%d", #entries)
-    -- fill with buffer
-    local bufferFirstIndex = self.buffer:fill(startIndex, targetEndIndex, entries);
-    
-    -- Assumption: buffer.lastIndex() == this.entriesInStore + this.startIndex
-    -- (Yes, for sure, we need to enforce this assumption to be true)
-    if(startIndex < bufferFirstIndex) then
-        -- in this case, we need to read from store file
-        local fileEntries = {}
-        local endi = bufferFirstIndex - self.startIndex;
-
-        openFile(self, "r")
-
-        self.indexFile:seek(start * DoubleBytes)
-        self.logger.trace("getLogEntries: start bytes:%d, indexfile pos:%d",  start * DoubleBytes, self.indexFile:getpos())
-        local dataStart = self.indexFile:ReadDouble();
-        for i = 1, (endi - start) do
-            local dataEnd = self.indexFile:ReadDouble();
-            local dataSize = dataEnd - dataStart;
-            self.dataFile:seek(dataStart);
-            -- self.logger.trace("getLogEntries: dataStart:%d, dataEnd:%d, indexfile pos:%d, datafile pos:%d", dataStart, dataEnd, self.indexFile:getpos(), self.dataFile:getpos());
-            -- here we should use i to index
-            fileEntries[i] = self:readEntry(dataSize);
-            dataStart = dataEnd;
-        end
-        for i=1,#entries do
-            fileEntries[#fileEntries+1] = entries[i];
-        end
-        entries = fileEntries
-
-
-        openFile(self, "rw")
-    end
-
-    return entries;
 end
 
 --[[
@@ -256,29 +101,7 @@ end
    @return the log entry or null if index >= {@code this.getFirstAvailableIndex()}
 ]]--
 function SequentialLogStore:getLogEntryAt(logIndex)
-    self.logger.trace("SequentialLogStore:getLogEntryAt>logIndex:%d, self.startIndex:%d, self.entriesInStore:%d",
-                       logIndex, self.startIndex, self.entriesInStore)
-    if logIndex < self.startIndex then
-        return;
-    end
 
-    local index = logIndex - self.startIndex + 1;
-    if(index > self.entriesInStore) then
-        return;
-    end
-
-    local entry = self.buffer:entryAt(logIndex);
-    if(entry ~= nil) then
-        return entry;
-    end
-
-    openFile(self, "r")
-    local indexPosition = (index - 1) * DoubleBytes;
-    self.indexFile:seek(indexPosition);
-    local dataPosition = self.indexFile:ReadDouble();
-    local endDataPosition = self.indexFile:ReadDouble();
-    self.dataFile:seek(dataPosition);
-    return self:readEntry(endDataPosition - dataPosition)
  end
 
 --[[
@@ -288,74 +111,7 @@ function SequentialLogStore:getLogEntryAt(logIndex)
    @return log pack
 ]]--
 function SequentialLogStore:packLog(logIndex, itemsToPack)
-    self.logger.trace("SequentialLogStore:packLog>logIndex:%d, itemsToPack:%d, self.startIndex:%d, entriesInStore:%d",
-                       logIndex, itemsToPack, self.startIndex, self.entriesInStore);
-    if logIndex < self.startIndex then
-        return;
-    end
 
-    local index = logIndex - self.startIndex + 1;
-    if(index > self.entriesInStore) then
-        return {};
-    end
-
-    openFile(self, "r")
-
-    local endIndex = math.min(index + itemsToPack, self.entriesInStore + 1);
-    local readToEnd = (endIndex == self.entriesInStore + 1);
-    local indexPosition = (index - 1) * DoubleBytes;
-    self.indexFile:seek(indexPosition);
-
-    local startOfLog = self.indexFile:ReadDouble();
-    local endOfLog = self.dataFile:GetFileSize();
-    local indexBytes = DoubleBytes * (endIndex - index)
-    if(not readToEnd) then
-        -- self.indexFile:seekRelative(indexBytes)
-        self.indexFile:seek(indexPosition + indexBytes)
-        endOfLog = self.indexFile:ReadDouble();
-    end
-
-    self.dataFile:seek(startOfLog);
-
-    -- "<memory>" is a special name for memory file, both read/write is possible. 
-    local file = ParaIO.open("<memory>", "w");
-    local bytes;
-    if(file:IsValid()) then
-        local dataBytes = endOfLog - startOfLog
-        self.logger.trace("SequentialLogStore:packLog>indexBytes:%d, dataBytes:%d", indexBytes, dataBytes)
-        file:WriteDouble(indexBytes)
-        file:WriteDouble(dataBytes)
-       
-        -- index data
-        local indexBuffer = self.indexFile:GetText(indexPosition, indexBytes)
-        assert(#indexBuffer == indexBytes, format("indexBuffer:%d len ~= indexBytes:%d len", #indexBuffer, indexBytes));
-        -- writeBytes(file, indexBuffer)
-        -- file:WriteBytes(indexBytes, {indexBuffer:byte(1, -1)})
-        file:write(indexBuffer, indexBytes)
-
-        -- data
-        local dataBuffer = self.dataFile:GetText(startOfLog, dataBytes);
-        assert(#dataBuffer == dataBytes, format("dataBuffer:%d len ~= dataBytes:%d len", #dataBuffer, dataBytes));
-        -- writeBytes(file, dataBuffer)
-        -- file:WriteBytes(dataBytes, {dataBuffer:byte(1, -1)})
-        file:write(dataBuffer, dataBytes)
-
-
-        bytes = file:GetText(0, -1)
-        file:close()
-	 
-        -- Compress
-        local data = {content=bytes, method="gzip"};
-        if(NPL.Compress(data)) then
-            bytes = data.result;
-        end
-    end
-    openFile(self, "rw")
-    
-    return bytes;
-
-    -- error handle
-    -- self.logger.error("failed to read files to read data for packing");
 end
 
 --[[
@@ -364,76 +120,7 @@ end
    @param logPack
 ]]--
 function SequentialLogStore:applyLogPack(logIndex, logPack)
-   self.logger.trace("SequentialLogStore:applyLogPack>logIndex:%d, self.startIndex:%d, entriesInStore:%d",
-                     logIndex, self.startIndex, self.entriesInStore);
-   if logIndex < self.startIndex then
-        return;
-    end
 
-    local index = logIndex - self.startIndex + 1;
-
-    local bytes;
-    local data = {content=logPack, method="gzip"};
-    
-    if(NPL.Decompress(data)) then
-        bytes = data.result;
-    end
-
-    -- "<memory>" is a special name for memory file, both read/write is possible. 
-    local file = ParaIO.open("<memory>", "w");
-    if(file:IsValid()) then
-        file:write(bytes, #bytes)
-        file:seek(0)
-
-        local indexBytes = file:ReadDouble()
-        local dataBytes = file:ReadDouble()
-
-        local indexBuffer = {}
-        local logBuffer = {}
-       
-        -- index data
-        file:ReadBytes(indexBytes, indexBuffer)
-        file:ReadBytes(dataBytes, logBuffer)
-        assert(#indexBuffer == indexBytes, format("indexBuffer:%d len ~= indexBytes:%d len", #indexBuffer, indexBytes));        
-        assert(#logBuffer == dataBytes, format("logBuffer:%d len ~= dataBytes:%d len", #logBuffer, dataBytes));
-        self.logger.trace("SequentialLogStore:applyLogPack>indexBytes:%d, dataBytes:%d", indexBytes, dataBytes)
-
-        local indexFilePosition, dataFilePosition;
-        openFile(self, "r")
-        if(index == self.entriesInStore + 1) then
-            indexFilePosition = self.indexFile:GetFileSize();
-            dataFilePosition = self.dataFile:GetFileSize();
-        else
-            indexFilePosition = (index - 1) * DoubleBytes;
-            self.indexFile:seek(indexFilePosition);
-            dataFilePosition = self.indexFile:ReadDouble();
-        end
-        openFile(self, "rw")
-
-        self.logger.trace("SequentialLogStore:applyLogPack>indexFilePosition:%d, dataFilePosition:%d", indexFilePosition, dataFilePosition);
-        self.indexFile:seek(indexFilePosition);
-        self.indexFile:WriteBytes(indexBytes, indexBuffer);
-        self.indexFile:SetFilePointer(indexFilePosition+indexBytes, 0);
-        self.indexFile:SetEndOfFile();
-        
-        self.dataFile:seek(dataFilePosition);
-        self.dataFile:WriteBytes(dataBytes, logBuffer);
-        self.dataFile:SetFilePointer(dataFilePosition+dataBytes, 0);
-        self.dataFile:SetEndOfFile();
-        self.entriesInStore = index - 1 + indexBytes / DoubleBytes;
-
-        -- openFile(self, "r")
-        -- assert(indexFilePosition+indexBytes == self.indexFile:GetFileSize(), format("index pos:%d ~= filesize:%d",indexFilePosition+indexBytes,self.indexFile:GetFileSize()))
-        -- assert(dataFilePosition+dataBytes == self.dataFile:GetFileSize(), format("data pos:%d ~= filesize:%d",dataFilePosition+dataBytes,self.dataFile:GetFileSize()))
-        -- openFile(self, "rw")
-
-        self.buffer:reset(self.entriesInStore > self.bufferSize and self.entriesInStore + self.startIndex - self.bufferSize or self.startIndex);
-        self:fillBuffer();
-        file:close()
-    end
-
-    -- error handle
-    -- self.logger.error("failed to write files to unpack logs for data");
 end
 
 --[[
@@ -442,197 +129,5 @@ end
    @return compact successfully or not
 ]]--
 function SequentialLogStore:compact(lastLogIndex)
-    if lastLogIndex < self.startIndex then
-        return;
-    end
 
-    self:backup();
-    local lastIndex = lastLogIndex - self.startIndex;
-    if(lastLogIndex >= self:getFirstAvailableIndex() - 1) then
-        self.indexFile:seek(0)
-        self.indexFile:SetEndOfFile();
-        self.dataFile:seek(0);
-        self.dataFile:SetEndOfFile();
-        self.startIndexFile:seek(0);
-        self.startIndexFile:WriteDouble(lastLogIndex + 1);
-        self.startIndex = lastLogIndex + 1;
-        self.entriesInStore = 0;
-        self.buffer:reset(lastLogIndex + 1);
-        return true;
-    else
-        openFile(self, "r")
-        local dataPosition = -1;
-        local indexPosition = DoubleBytes * (lastIndex + 1);
-        self.indexFile:seek(indexPosition);
-        dataPosition = self.indexFile:ReadDouble()
-        local indexFileNewLength = self.indexFile:GetFileSize() - indexPosition;
-        local dataFileNewLength = self.dataFile:GetFileSize() - dataPosition;
-
-        openFile(self, "rw")
-
-        -- copy the log data
-        -- data file
-        local backupFile = ParaIO.open(self.backupDataFileName, "r");
-        assert(backupFile:IsValid(), "dataFile not Valid")
-
-        -- we don't have an channel, so this is inefficient and ugly
-        backupFile:seek(dataPosition);
-        local data = {}
-        backupFile:ReadBytes(dataFileNewLength, data)
-        self.dataFile:seek(0)
-        self.dataFile:WriteBytes(dataFileNewLength, data)
-        self.dataFile:SetEndOfFile()
-        backupFile:close();
-
-        -- copy the index data
-        -- index file
-        backupFile = ParaIO.open(self.backupIndexFileName, "r");
-        assert(backupFile:IsValid(), "backupFile not Valid")
-
-        
-        backupFile:seek(indexPosition);
-        self.indexFile:seek(0);
-        for  i = 1, indexFileNewLength / DoubleBytes do
-            self.indexFile:WriteDouble(backupFile:ReadDouble() - dataPosition);
-        end
-
-        self.indexFile:SetEndOfFile();
-        backupFile:close();
-
-        -- save the starting index
-        self.startIndexFile:seek(0);
-        self.startIndexFile:WriteDouble(lastLogIndex + 1);
-        self.entriesInStore = self.entriesInStore - (lastLogIndex - self.startIndex + 1);
-        self.startIndex = lastLogIndex + 1;
-        self.buffer:reset(self.entriesInStore > self.bufferSize and self.entriesInStore + self.startIndex - self.bufferSize or self.startIndex);
-        self:fillBuffer();
-        return true;
-    end
-
-    self.logger.error("fail to compact the logs due to error");
-    self:restore();
-    return false;
-end
-
-function SequentialLogStore:fillBuffer()
-    openFile(self, "r")
-    local startIndex = self.buffer:firstIndex();
-    local indexFileSize = self.indexFile:GetFileSize();
-    if(indexFileSize > 0) then
-        local indexPosition = (startIndex - self.startIndex) * DoubleBytes;
-        self.indexFile:seek(indexPosition);
-        local dataStart = self.indexFile:ReadDouble();
-        self.dataFile:seek(dataStart);
-        while(self.indexFile:getpos() < indexFileSize) do
-            local dataEnd = self.indexFile:ReadDouble();
-            self.logger.trace("SequentialLogStore:fillBuffer>dataStart:%d, dataEnd:%d", dataStart, dataEnd)
-            local entry = self:readEntry(dataEnd - dataStart);
-            -- util.table_print(entry)
-            self.buffer:append(entry);
-            dataStart = dataEnd;
-        end
-        self.logger.trace("SequentialLogStore:fillBuffer>dataStart:%d, dataEnd:%d", dataStart, self.dataFile:GetFileSize())
-        local entry = self:readEntry(self.dataFile:GetFileSize() - dataStart);
-        self.buffer:append(entry);
-    end
-    -- self.logger.trace("SequentialLogStore:fillBuffer>buffer firstIndex:%d, entries:%d", self.buffer:firstIndex(), self.buffer:bufferSize())
-    openFile(self, "rw")
-end
-
-
-function SequentialLogStore:restore()
-    self:closeFiles();
-
-    if not (ParaIO.CopyFile(self.backupIndexFileName, self.indexFileName, true) and
-        ParaIO.CopyFile(self.backupDataFileName, self.dataFileName, true) and
-        ParaIO.CopyFile(self.backupStartIndexFileName, self.startIndexFileName, true)) then
-        -- this is fatal...
-        self.logger.fatal("cannot restore from failure, please manually restore the log files");
-    end
-    openFile(self, "rw")
-end
-
-function SequentialLogStore:backup()
-    self:close()
-    --decide not to use ParaIO.BackupFile
-    ParaIO.DeleteFile(self.backupDataFileName)
-    ParaIO.DeleteFile(self.backupIndexFileName)
-    ParaIO.DeleteFile(self.backupStartIndexFileName)
-
-    if not (ParaIO.CopyFile(self.indexFileName, self.backupIndexFileName, true) and
-        ParaIO.CopyFile(self.dataFileName, self.backupDataFileName, true) and
-        ParaIO.CopyFile(self.startIndexFileName, self.backupStartIndexFileName, true)) then
-        self.logger.error("failed to create a backup folder")
-    end
-
-    openFile(self, "rw")
-end
-
-
-function SequentialLogStore:readEntry(size)
-    local term = self.dataFile:ReadDouble();
-    local valueTypeByte = {}
-    self.dataFile:ReadBytes(1, valueTypeByte);
-    local valueType = valueTypeByte[1]
-    local valueBytes = {}
-    -- print(format("SequentialLogStore:readEntry>%d", size-DoubleBytes-1))
-    assert(size-DoubleBytes-1 > 0, "size error")
-    self.dataFile:ReadBytes(size-DoubleBytes-1, valueBytes);
-    -- util.table_print(valueBytes)
-    local value = string.char(unpack(valueBytes))
-    -- local value = self.dataFile:ReadBytes(size-DoubleBytes-1, nil);
-    return LogEntry:new(term, value, valueType);
-end
-
-function SequentialLogStore:closeFiles()
-    self.indexFile:close()
-    self.dataFile:close()
-    self.startIndexFile:close()
-end
-function SequentialLogStore:close()
-    self:closeFiles()
-    self.prevMode = nil;
-end
-
-function openFile(logStore, mode)
-    if mode == logStore.prevMode then
-        return;
-    else
-        logStore.prevMode = mode
-    end
-    if logStore.indexFile and logStore.dataFile and logStore.startIndexFile then
-        logStore:closeFiles()
-    end
-    -- index file
-    logStore.indexFile = ParaIO.open(logStore.indexFileName, mode);
-    -- assert(logStore.indexFile:IsValid(), "indexFile not Valid")
-
-    -- data file
-    logStore.dataFile = ParaIO.open(logStore.dataFileName, mode);
-    -- assert(logStore.dataFile:IsValid(), "dataFile not Valid")
-
-    -- startIndex file
-    logStore.startIndexFile = ParaIO.open(logStore.startIndexFileName, mode);
-    -- assert(logStore.startIndexFile:IsValid(), "startIndexFile not Valid")
-
-    local valid = logStore.indexFile:IsValid() and logStore.dataFile:IsValid() and logStore.startIndexFile:IsValid();
-    if not valid then
-        mode = "rw"
-        return openFile(logStore, mode)
-    end
-end
-
-function writeBytes(file, indexBuffer)
-    if #indexBuffer > 1024 then
-        local start_pos = 1
-        local end_pos = 1024
-        while start_pos < #indexBuffer do
-            file:WriteBytes(end_pos - start_pos + 1, {indexBuffer:byte(start_pos, end_pos)})
-            start_pos = end_pos + 1;
-            end_pos = end_pos + 1024;
-        end
-    else
-        -- file:WriteBytes(#indexBuffer, {indexBuffer:byte(1, -1)})
-        file:write(indexBuffer, indexBuffer)
-    end
 end

--- a/npl_mod/Raft/ServerStateManager.lua
+++ b/npl_mod/Raft/ServerStateManager.lua
@@ -15,13 +15,16 @@ NPL.load("(gl)script/ide/Files.lua");
 NPL.load("(gl)script/ide/Json.lua");
 NPL.load("(gl)npl_mod/Raft/ClusterConfiguration.lua");
 NPL.load("(gl)npl_mod/Raft/ServerState.lua");
-NPL.load("(gl)npl_mod/Raft/FileBasedSequentialLogStore.lua");
+-- NPL.load("(gl)npl_mod/Raft/FileBasedSequentialLogStore.lua");
+-- local FileBasedSequentialLogStore = commonlib.gettable("Raft.FileBasedSequentialLogStore");
+NPL.load("(gl)npl_mod/Raft/WALSequentialLogStore.lua");
+local WALSequentialLogStore = commonlib.gettable("Raft.WALSequentialLogStore");
 local LoggerFactory = NPL.load("(gl)npl_mod/Raft/LoggerFactory.lua");
-local FileBasedSequentialLogStore = commonlib.gettable("Raft.FileBasedSequentialLogStore");
 local ServerState = commonlib.gettable("Raft.ServerState");
 local ClusterConfiguration = commonlib.gettable("Raft.ClusterConfiguration");
 local ServerStateManager = commonlib.gettable("Raft.ServerStateManager");
 
+local SequentialLogStore = WALSequentialLogStore
 local STATE_FILE = "server.state";
 local CONFIG_FILE = "config.properties";
 local CLUSTER_CONFIG_FILE = "cluster.json";
@@ -30,7 +33,7 @@ local CLUSTER_CONFIG_FILE = "cluster.json";
 function ServerStateManager:new(dataDirectory)
     local o = {
         container = dataDirectory,
-        logStore = FileBasedSequentialLogStore:new(dataDirectory),
+        logStore = SequentialLogStore:new(dataDirectory),
         logger = LoggerFactory.getLogger("ServerStateManager")
     };
     setmetatable(o, self);

--- a/npl_mod/Raft/SqliteBasedServerStateManager.lua
+++ b/npl_mod/Raft/SqliteBasedServerStateManager.lua
@@ -1,0 +1,122 @@
+--[[
+Title:
+Author: liuluheng
+Date: 2017.03.25
+Desc:
+    FileBased is better
+    FIXME: use sqlite instead of TableDB
+
+------------------------------------------------------------
+NPL.load("(gl)npl_mod/Raft/SqliteBasedServerStateManager.lua");
+local SqliteBasedServerStateManager = commonlib.gettable("Raft.SqliteBasedServerStateManager");
+------------------------------------------------------------
+]]
+--
+NPL.load("(gl)script/ide/Files.lua");
+NPL.load("(gl)script/ide/Json.lua");
+NPL.load("(gl)npl_mod/Raft/ClusterConfiguration.lua");
+NPL.load("(gl)npl_mod/Raft/ServerState.lua");
+NPL.load("(gl)script/ide/System/Database/TableDatabase.lua");
+local TableDatabase = commonlib.gettable("System.Database.TableDatabase");
+-- NPL.load("(gl)npl_mod/Raft/FileBasedSequentialLogStore.lua");
+-- local FileBasedSequentialLogStore = commonlib.gettable("Raft.FileBasedSequentialLogStore");
+NPL.load("(gl)npl_mod/Raft/WALSequentialLogStore.lua");
+local WALSequentialLogStore = commonlib.gettable("Raft.WALSequentialLogStore");
+local LoggerFactory = NPL.load("(gl)npl_mod/Raft/LoggerFactory.lua");
+local ServerState = commonlib.gettable("Raft.ServerState");
+local ClusterConfiguration = commonlib.gettable("Raft.ClusterConfiguration");
+
+local SqliteBasedServerStateManager = commonlib.gettable("Raft.SqliteBasedServerStateManager");
+
+local SequentialLogStore = WALSequentialLogStore
+local STATE_FILE = "server.state";
+local CONFIG_FILE = "config.properties";
+local CLUSTER_CONFIG_FILE = "cluster.json";
+
+
+function SqliteBasedServerStateManager:new(dataDirectory)
+    local o = {
+        container = dataDirectory,
+        logStore = SequentialLogStore:new(dataDirectory),
+        logger = LoggerFactory.getLogger("SqliteBasedServerStateManager"),
+        -- this will start both db client and db server if not.
+        db = TableDatabase:new():connect(dataDirectory, function() end);
+    };
+    setmetatable(o, self);
+    
+    local configFile = ParaIO.open(o.container .. CONFIG_FILE, "r");
+    if configFile:IsValid() then
+        local line = configFile:readline()
+        local index = string.find(line, "=")
+        o.serverId = tonumber(string.sub(line, index + 1))
+    end
+    
+    o.db:EnableSyncMode(true);
+    
+    -- o.db.serverState:insertOne(nil, {serverId=o.serverId});
+    return o;
+end
+
+function SqliteBasedServerStateManager:__index(name)
+    return rawget(self, name) or SqliteBasedServerStateManager[name];
+end
+
+function SqliteBasedServerStateManager:__tostring()
+    return util.table_tostring(self)
+end
+
+
+-- Load cluster configuration for this server
+function SqliteBasedServerStateManager:loadClusterConfiguration()
+    local filename = self.container .. CLUSTER_CONFIG_FILE
+    local configFile = ParaIO.open(filename, "r");
+    if configFile:IsValid() then
+        local text = configFile:GetText();
+        local config = commonlib.Json.Decode(text);
+        return ClusterConfiguration:new(config);
+    else
+        self.logger.error("%s path error", filename)
+    end
+end
+
+-- Save cluster configuration
+function SqliteBasedServerStateManager:saveClusterConfiguration(configuration)
+    local config = commonlib.Json.Encode(configuration);
+    local filename = self.container .. CLUSTER_CONFIG_FILE
+    local configFile = ParaIO.open(filename, "w");
+    if configFile:IsValid() then
+        configFile:WriteString(config);
+        configFile:close()
+    else
+        self.logger.error("%s path error", filename)
+    end
+end
+
+
+function SqliteBasedServerStateManager:persistState(serverState)
+    self.logger.trace("persistState>term:%f,commitIndex:%f,votedFor:%f",
+        serverState.term, serverState.commitIndex, serverState.votedFor);
+    -- self.db.serverState:deleteOne({serverId = self.serverId});
+    self.db.serverState:insertOne({serverId = self.serverId}, {
+        serverId = self.serverId,
+        term = serverState.term,
+        commitIndex = serverState.commitIndex,
+        votedFor = serverState.votedFor,
+    });
+end
+
+function SqliteBasedServerStateManager:readState()
+    local serverState;
+    local err, data = self.db.serverState:findOne({serverId = self.serverId});
+    if not err and data then
+        serverState = ServerState:new(data.term, data.commitIndex, data.votedFor);
+    else
+        self.logger.error("persistState first");
+    end
+    
+    return serverState;
+end
+
+function SqliteBasedServerStateManager:close()
+    self.logStore:close();
+end

--- a/npl_mod/Raft/WALLogBuffer.lua
+++ b/npl_mod/Raft/WALLogBuffer.lua
@@ -67,6 +67,9 @@ function WALLogBuffer:writeAt(index, logEntry)
         return;
     end
     self.buffer[index] = logEntry;
+    if index == self:lastIndex() + 1 then
+        self.entriesInBuffer = self.entriesInBuffer + 1;
+    end
 end
 
 -- [start, end), returns the startIndex

--- a/npl_mod/Raft/WALLogBuffer.lua
+++ b/npl_mod/Raft/WALLogBuffer.lua
@@ -85,7 +85,7 @@ function WALLogBuffer:fill(start, endi, result)
         result[#result + 1] = self:entryAt(i)
     end
     
-    self.logger.trace("fill>start:%d, end:%d, result len:%d, self.startIndex:%d, self.buffer len:%d",
+    self.logger.trace("fill>start:%d, end:%d, result len:%d, startIndex:%d, bufferLen:%d",
         start, endi, #result, self.startIndex, self:bufferSize())
     -- self.logger.trace("fill>result:%s", util.table_tostring(result))
     return self.startIndex;

--- a/npl_mod/Raft/WALLogBuffer.lua
+++ b/npl_mod/Raft/WALLogBuffer.lua
@@ -1,0 +1,130 @@
+--[[
+Title: 
+Author: liuluheng
+Date: 2017.03.25
+Desc: 
+    the WALLogBuffer is startIndex based
+------------------------------------------------------------
+NPL.load("(gl)npl_mod/Raft/WALLogBuffer.lua");
+local WALLogBuffer = commonlib.gettable("Raft.WALLogBuffer");
+------------------------------------------------------------
+]]--
+
+local LoggerFactory = NPL.load("(gl)npl_mod/Raft/LoggerFactory.lua");
+NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
+local util = commonlib.gettable("System.Compiler.lib.util")
+NPL.load("(gl)npl_mod/Raft/Rutils.lua");
+local Rutils = commonlib.gettable("Raft.Rutils");
+local WALLogBuffer = commonlib.gettable("Raft.WALLogBuffer");
+
+
+function WALLogBuffer:new(startIndex, maxSize) 
+    local o = {
+        startIndex = startIndex,
+        entriesInBuffer = 0,
+        maxSize = maxSize,
+        logger = LoggerFactory.getLogger("WALLogBuffer"),
+        buffer = {},
+    };
+    setmetatable(o, self);
+    return o;
+end
+
+function WALLogBuffer:__index(name)
+    return rawget(self, name) or WALLogBuffer[name];
+end
+
+function WALLogBuffer:__tostring()
+    return util.table_tostring(self)
+end
+
+
+
+function WALLogBuffer:lastIndex()
+    return self.startIndex + self.entriesInBuffer - 1;
+end
+
+
+function WALLogBuffer:firstIndex()
+    return self.startIndex;
+end
+
+
+function WALLogBuffer:lastEntry()
+    -- if buffer size = 0, will return nil
+    return self.buffer[self:lastIndex()]
+end
+
+function WALLogBuffer:entryAt(index)
+    -- self.logger.trace("entryAt>index:%d, self.startIndex:%d, self.buffer len:%d",
+    --                    index, self.startIndex, self:bufferSize())
+    return self.buffer[index];
+end
+
+function WALLogBuffer:writeAt(index, logEntry)
+    if index < self:firstIndex() and index > self:lastIndex() + 1 then
+        self.logger.error("badly wrong!! this must be a bug!");
+        return;
+    end
+    self.buffer[index] = logEntry;
+end
+
+-- [start, end), returns the startIndex
+function WALLogBuffer:fill(start, endi, result)
+    if endi < self.startIndex then
+        return self.startIndex;
+    end
+
+    if start < self.startIndex then
+        start = self.startIndex
+    end
+    for i=start, endi - 1 do
+        result[#result + 1] = self:entryAt(i)
+    end
+
+    self.logger.trace("fill>start:%d, end:%d, result len:%d, self.startIndex:%d, self.buffer len:%d",
+                       start, endi, #result, self.startIndex, self:bufferSize())
+    -- self.logger.trace("fill>result:%s", util.table_tostring(result))
+
+    return self.startIndex;
+end
+
+
+-- trimming the buffer [fromIndex, end)
+function WALLogBuffer:trim(fromIndex)
+    if fromIndex < self:lastIndex() + 1 then
+        for i=fromIndex, self:lastIndex() do
+            self.buffer[i] = nil
+            self.entriesInBuffer = self.entriesInBuffer - 1;
+        end
+    end
+end
+
+function WALLogBuffer:append(entry)
+
+    self.buffer[self:lastIndex() + 1] = entry
+    self.entriesInBuffer = self.entriesInBuffer + 1;
+    -- self.logger.trace("append>index:%d->%s, self.startIndex:%d, self.buffer len:%d",
+    --                    self:lastIndex(), util.table_tostring(entry), self.startIndex, self:bufferSize())
+    -- TODO: make unbound
+    -- maxSize
+    -- if self.maxSize < self.entriesInBuffer then
+    --     self.buffer[self.startIndex] = nil
+    --     self.startIndex = self.startIndex + 1
+    --     self.entriesInBuffer = self.entriesInBuffer - 1;
+    -- end
+end
+
+function WALLogBuffer:reset(startIndex)
+    if startIndex > self.startIndex then
+        for i=self.startIndex, startIndex - 1 do
+            self.buffer[i] = nil
+            self.entriesInBuffer = self.entriesInBuffer - 1;
+        end
+    end
+    self.startIndex = startIndex
+end
+
+function WALLogBuffer:bufferSize()
+    return self.entriesInBuffer
+end

--- a/npl_mod/Raft/WALLogBuffer.lua
+++ b/npl_mod/Raft/WALLogBuffer.lua
@@ -1,15 +1,15 @@
 --[[
-Title: 
+Title:
 Author: liuluheng
 Date: 2017.03.25
-Desc: 
-    the WALLogBuffer is startIndex based
+Desc:
+the WALLogBuffer is startIndex based
 ------------------------------------------------------------
 NPL.load("(gl)npl_mod/Raft/WALLogBuffer.lua");
 local WALLogBuffer = commonlib.gettable("Raft.WALLogBuffer");
 ------------------------------------------------------------
-]]--
-
+]]
+--
 local LoggerFactory = NPL.load("(gl)npl_mod/Raft/LoggerFactory.lua");
 NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
 local util = commonlib.gettable("System.Compiler.lib.util")
@@ -18,7 +18,7 @@ local Rutils = commonlib.gettable("Raft.Rutils");
 local WALLogBuffer = commonlib.gettable("Raft.WALLogBuffer");
 
 
-function WALLogBuffer:new(startIndex, maxSize) 
+function WALLogBuffer:new(startIndex, maxSize)
     local o = {
         startIndex = startIndex,
         entriesInBuffer = 0,
@@ -74,18 +74,17 @@ function WALLogBuffer:fill(start, endi, result)
     if endi < self.startIndex then
         return self.startIndex;
     end
-
+    
     if start < self.startIndex then
         start = self.startIndex
     end
-    for i=start, endi - 1 do
+    for i = start, endi - 1 do
         result[#result + 1] = self:entryAt(i)
     end
-
+    
     self.logger.trace("fill>start:%d, end:%d, result len:%d, self.startIndex:%d, self.buffer len:%d",
-                       start, endi, #result, self.startIndex, self:bufferSize())
+        start, endi, #result, self.startIndex, self:bufferSize())
     -- self.logger.trace("fill>result:%s", util.table_tostring(result))
-
     return self.startIndex;
 end
 
@@ -93,7 +92,7 @@ end
 -- trimming the buffer [fromIndex, end)
 function WALLogBuffer:trim(fromIndex)
     if fromIndex < self:lastIndex() + 1 then
-        for i=fromIndex, self:lastIndex() do
+        for i = fromIndex, self:lastIndex() do
             self.buffer[i] = nil
             self.entriesInBuffer = self.entriesInBuffer - 1;
         end
@@ -101,23 +100,23 @@ function WALLogBuffer:trim(fromIndex)
 end
 
 function WALLogBuffer:append(entry)
-
+    
     self.buffer[self:lastIndex() + 1] = entry
     self.entriesInBuffer = self.entriesInBuffer + 1;
-    -- self.logger.trace("append>index:%d->%s, self.startIndex:%d, self.buffer len:%d",
-    --                    self:lastIndex(), util.table_tostring(entry), self.startIndex, self:bufferSize())
-    -- TODO: make unbound
-    -- maxSize
-    -- if self.maxSize < self.entriesInBuffer then
-    --     self.buffer[self.startIndex] = nil
-    --     self.startIndex = self.startIndex + 1
-    --     self.entriesInBuffer = self.entriesInBuffer - 1;
-    -- end
+-- self.logger.trace("append>index:%d->%s, self.startIndex:%d, self.buffer len:%d",
+--                    self:lastIndex(), util.table_tostring(entry), self.startIndex, self:bufferSize())
+-- make unbound
+-- maxSize
+-- if self.maxSize < self.entriesInBuffer then
+--     self.buffer[self.startIndex] = nil
+--     self.startIndex = self.startIndex + 1
+--     self.entriesInBuffer = self.entriesInBuffer - 1;
+-- end
 end
 
 function WALLogBuffer:reset(startIndex)
     if startIndex > self.startIndex then
-        for i=self.startIndex, startIndex - 1 do
+        for i = self.startIndex, startIndex - 1 do
             self.buffer[i] = nil
             self.entriesInBuffer = self.entriesInBuffer - 1;
         end

--- a/npl_mod/Raft/WALSequentialLogStore.lua
+++ b/npl_mod/Raft/WALSequentialLogStore.lua
@@ -1,46 +1,49 @@
 --[[
-Title: 
+Title:
 Author: liuluheng
 Date: 2017.03.25
-Desc: 
-
-NPL file API dose not support u GetFileSize in "rw" mode(and variou things like this),
-so the code is a bit ugly :(
-
+Desc:
+    not touch the disk.
 ------------------------------------------------------------
 NPL.load("(gl)npl_mod/Raft/WALSequentialLogStore.lua");
 local WALSequentialLogStore = commonlib.gettable("Raft.WALSequentialLogStore");
 ------------------------------------------------------------
-]]--
+]]
+--
 NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
 local util = commonlib.gettable("System.Compiler.lib.util")
 NPL.load("(gl)npl_mod/Raft/LogEntry.lua");
 local LogEntry = commonlib.gettable("Raft.LogEntry");
-NPL.load("(gl)npl_mod/Raft/LogBuffer.lua");
-local LogBuffer = commonlib.gettable("Raft.LogBuffer");
+NPL.load("(gl)npl_mod/Raft/WALLogBuffer.lua");
+local WALLogBuffer = commonlib.gettable("Raft.WALLogBuffer");
+NPL.load("(gl)script/ide/System/Database/TableDatabase.lua");
+local TableDatabase = commonlib.gettable("System.Database.TableDatabase");
 
 local LoggerFactory = NPL.load("(gl)npl_mod/Raft/LoggerFactory.lua");
+local LogValueType = NPL.load("(gl)npl_mod/Raft/LogValueType.lua");
 
 local WALSequentialLogStore = commonlib.gettable("Raft.WALSequentialLogStore");
 
 local BUFFER_SIZE = 1000;
 
-local openFile;
 
-function WALSequentialLogStore:new(logContainer) 
+function WALSequentialLogStore:new(logContainer)
     local o = {
         logContainer = logContainer,
         logger = LoggerFactory.getLogger("WALSequentialLogStore"),
         zeroEntry = LogEntry:new(),
+        -- actually not used
         bufferSize = BUFFER_SIZE,
+        -- this will start both db client and db server if not.
+        db = TableDatabase:new():connect(logContainer, function() end);
     };
     setmetatable(o, self);
-
+    
     -- always start from 1, 0, emptyBuffer
     o.startIndex = 1;
     o.entriesInStore = 0;
-    o.buffer = LogBuffer:new(o.startIndex, o.bufferSize);
-
+    o.buffer = WALLogBuffer:new(o.startIndex, o.bufferSize);
+    
     return o;
 end
 
@@ -53,88 +56,79 @@ function WALSequentialLogStore:__tostring()
 end
 
 --[[
-   The first available index of the store, starts with 1
-   @return value >= 1
-]]--
+The first available index of the store, starts with 1
+@return value >= 1
+]]
+--
 function WALSequentialLogStore:getFirstAvailableIndex()
     return self.entriesInStore + self.startIndex;
 end
 
 --[[
-   The start index of the log store, at the very beginning, it must be 1
-   however, after some compact actions, this could be anything greater or equals to one
-   @return start index of the log store
-]]--
+The start index of the log store, at the very beginning, it must be 1
+however, after some compact actions, this could be anything greater or equals to one
+@return start index of the log store
+]]
+--
 function WALSequentialLogStore:getStartIndex()
     return self.startIndex
 end
 
 --[[
-   The last log entry in store
-   @return a dummy constant entry with value set to null and term set to zero if no log entry in store
-]]--
+The last log entry in store
+@return a dummy constant entry with value set to null and term set to zero if no log entry in store
+]]
+--
 function WALSequentialLogStore:getLastLogEntry()
     local lastEntry = self.buffer:lastEntry();
     return (lastEntry == nil and self.zeroEntry) or lastEntry;
 end
 
 --[[
-   Appends a log entry to store
-   @param logEntry
-   @return the last appended log index
-]]--
+Appends a log entry to store
+@param logEntry
+@return the last appended log index
+]]
+--
 function WALSequentialLogStore:append(logEntry)
-    -- we do not touch disk
     self.entriesInStore = self.entriesInStore + 1;
     self.buffer:append(logEntry);
-    return self.entriesInStore + self.startIndex - 1;
+    
+    local logIndex = self.entriesInStore + self.startIndex - 1;
+    if logEntry.valueType ~= LogValueType.Application then
+        -- use TableDB deal with LogValueType other than Application
+        self.db.raftLog:insertOne(nil, {logIndex = logIndex, logEntry = logEntry, });
+    end
+    
+    return logIndex;
 end
 
 --[[
-   Over writes a log entry at index of {@code index}
-   @param index a value < {@code this.getFirstAvailableIndex()}, and starts from 1
-   @param logEntry
-]]--
+Over writes a log entry at index of {@code index}
+@param index a value < {@code this.getFirstAvailableIndex()}, and starts from 1
+@param logEntry
+]]
+--
 function WALSequentialLogStore:writeAt(logIndex, logEntry)
     if logIndex < self.startIndex then
         return;
     end
-
-    openFile(self, "r")
-
+    
     local index = logIndex - self.startIndex
-    -- find the positions for index and data files
-    local dataPosition = self.dataFile:GetFileSize();
-    local indexPosition = (index - 1) * DoubleBytes;
-    if(indexPosition < self.indexFile:GetFileSize()) then
-        self.indexFile:seek(indexPosition);
-        dataPosition = self.indexFile:ReadDouble();
-    end
-
-    local dataFileSize = self.dataFile:GetFileSize();
-    local indexFileSize = self.indexFile:GetFileSize();
-
-    openFile(self, "rw")
-    -- write the data at the specified position
-    self.indexFile:seek(indexPosition);
-    self.dataFile:seek(dataPosition);
-    self.indexFile:WriteDouble(dataPosition);
-    self.dataFile:WriteDouble(logEntry.term);
-    self.dataFile:WriteBytes(1, {logEntry.valueType});
-    -- self.dataFile:WriteBytes(#logEntry.value, {logEntry.value:byte(1, -1)});
-    self.dataFile:write(logEntry.value, #logEntry.value);
-
-    -- trim the files if necessary
-    if(indexFileSize > self.indexFile:getpos()) then
-        self.indexFile:SetEndOfFile();
-    end
-
-    if(dataFileSize > self.dataFile:getpos()) then
-        self.dataFile:SetEndOfFile();
-    end
-
-    if(index <= self.entriesInStore) then
+    if (index <= self.entriesInStore) then
         self.buffer:trim(logIndex);
+        
+        if logEntry.valueType ~= LogValueType.Application then
+            -- use TableDB deal with LogValueType other than Application
+            self.db.raftLog:find({_id = {gt = logIndex}}, function(err, data)
+                if not err and data then
+                    for _, v in ipairs(data) do
+                        self.db.raftLog:deleteOne({logIndex = data.logIndex});
+                    end
+                end
+            end);
+            self.db.raftLog:insertOne({logIndex = logIndex}, {logIndex = logIndex, logEntry = logEntry, });
+        end
     end
     
     self.buffer:append(logEntry);
@@ -142,449 +136,189 @@ function WALSequentialLogStore:writeAt(logIndex, logEntry)
 end
 
 --[[
-   Get log entries with index between {@code start} and {@code end}
-   @param start the start index of log entries
-   @param end the end index of log entries (exclusive)
-   @return the log entries between [start, end)
-]]--
+Get log entries with index between {@code start} and {@code end}
+@param start the start index of log entries
+@param end the end index of log entries (exclusive)
+@return the log entries between [start, end)
+]]
+--
 function WALSequentialLogStore:getLogEntries(startIndex, endIndex)
     self.logger.trace("getLogEntries:startIndex:%d, endIndex:%d, self.startIndex:%d, self.entriesInStore:%d",
-                       startIndex, endIndex, self.startIndex, self.entriesInStore)
+        startIndex, endIndex, self.startIndex, self.entriesInStore)
     if startIndex < self.startIndex then
         return;
     end
-
+    
     -- start and adjustedEnd are zero based, targetEndIndex is this.startIndex based
     local start = startIndex - self.startIndex;
     local adjustedEnd = endIndex - self.startIndex;
     adjustedEnd = (adjustedEnd > self.entriesInStore and self.entriesInStore) or adjustedEnd;
     local targetEndIndex = (endIndex > self.entriesInStore + self.startIndex + 1 and self.entriesInStore + self.startIndex + 1) or endIndex;
-
+    
     local entries = {}
     if adjustedEnd - start == 0 then
         return entries
     end
-
+    
     self.logger.trace("getLogEntries:pre fill entries len:%d", #entries)
     -- fill with buffer
     local bufferFirstIndex = self.buffer:fill(startIndex, targetEndIndex, entries);
     
     -- Assumption: buffer.lastIndex() == this.entriesInStore + this.startIndex
     -- (Yes, for sure, we need to enforce this assumption to be true)
-    if(startIndex < bufferFirstIndex) then
-        -- in this case, we need to read from store file
-        local fileEntries = {}
-        local endi = bufferFirstIndex - self.startIndex;
-
-        openFile(self, "r")
-
-        self.indexFile:seek(start * DoubleBytes)
-        self.logger.trace("getLogEntries: start bytes:%d, indexfile pos:%d",  start * DoubleBytes, self.indexFile:getpos())
-        local dataStart = self.indexFile:ReadDouble();
-        for i = 1, (endi - start) do
-            local dataEnd = self.indexFile:ReadDouble();
-            local dataSize = dataEnd - dataStart;
-            self.dataFile:seek(dataStart);
-            -- self.logger.trace("getLogEntries: dataStart:%d, dataEnd:%d, indexfile pos:%d, datafile pos:%d", dataStart, dataEnd, self.indexFile:getpos(), self.dataFile:getpos());
-            -- here we should use i to index
-            fileEntries[i] = self:readEntry(dataSize);
-            dataStart = dataEnd;
-        end
-        for i=1,#entries do
-            fileEntries[#fileEntries+1] = entries[i];
-        end
-        entries = fileEntries
-
-
-        openFile(self, "rw")
+    if (startIndex < bufferFirstIndex) then
+        -- should never goes here
+        self.logger.error("badly wrong!! getting entries not in the buffer")
     end
-
+    
     return entries;
 end
 
 --[[
-   Gets the log entry at the specified index
-   @param index starts from 1
-   @return the log entry or null if index >= {@code this.getFirstAvailableIndex()}
-]]--
+Gets the log entry at the specified index
+@param index starts from 1
+@return the log entry or null if index >= {@code this.getFirstAvailableIndex()}
+]]
+--
 function WALSequentialLogStore:getLogEntryAt(logIndex)
-    self.logger.trace("WALSequentialLogStore:getLogEntryAt>logIndex:%d, self.startIndex:%d, self.entriesInStore:%d",
-                       logIndex, self.startIndex, self.entriesInStore)
+    self.logger.trace("getLogEntryAt>logIndex:%d, self.startIndex:%d, self.entriesInStore:%d",
+        logIndex, self.startIndex, self.entriesInStore)
     if logIndex < self.startIndex then
         return;
     end
-
+    
     local index = logIndex - self.startIndex + 1;
-    if(index > self.entriesInStore) then
+    if (index > self.entriesInStore) then
         return;
     end
-
+    
     local entry = self.buffer:entryAt(logIndex);
-    if(entry ~= nil) then
+    if (entry ~= nil) then
         return entry;
+    else
+        -- should never goes here
+        self.db.raftLog:find({logIndex = logIndex}, function(err, data)
+            if not err and data.logEntry then
+                entry = data.logEntry
+            else
+                self.logger.error("badly wrong!! getting an entry not in the raftLog DB");
+            end
+        end)
     end
-
-    openFile(self, "r")
-    local indexPosition = (index - 1) * DoubleBytes;
-    self.indexFile:seek(indexPosition);
-    local dataPosition = self.indexFile:ReadDouble();
-    local endDataPosition = self.indexFile:ReadDouble();
-    self.dataFile:seek(dataPosition);
-    return self:readEntry(endDataPosition - dataPosition)
- end
+end
 
 --[[
-   Pack {@code itemsToPack} log items starts from {@code index}
-   @param index
-   @param itemsToPack
-   @return log pack
-]]--
+Pack {@code itemsToPack} log items starts from {@code index}
+@param index
+@param itemsToPack
+@return log pack
+]]
+--
 function WALSequentialLogStore:packLog(logIndex, itemsToPack)
-    self.logger.trace("WALSequentialLogStore:packLog>logIndex:%d, itemsToPack:%d, self.startIndex:%d, entriesInStore:%d",
-                       logIndex, itemsToPack, self.startIndex, self.entriesInStore);
+    self.logger.trace("packLog>logIndex:%d, itemsToPack:%d, self.startIndex:%d, entriesInStore:%d",
+        logIndex, itemsToPack, self.startIndex, self.entriesInStore);
     if logIndex < self.startIndex then
         return;
     end
-
+    
     local index = logIndex - self.startIndex + 1;
-    if(index > self.entriesInStore) then
+    if (index > self.entriesInStore) then
         return {};
     end
-
-    openFile(self, "r")
-
-    local endIndex = math.min(index + itemsToPack, self.entriesInStore + 1);
-    local readToEnd = (endIndex == self.entriesInStore + 1);
-    local indexPosition = (index - 1) * DoubleBytes;
-    self.indexFile:seek(indexPosition);
-
-    local startOfLog = self.indexFile:ReadDouble();
-    local endOfLog = self.dataFile:GetFileSize();
-    local indexBytes = DoubleBytes * (endIndex - index)
-    if(not readToEnd) then
-        -- self.indexFile:seekRelative(indexBytes)
-        self.indexFile:seek(indexPosition + indexBytes)
-        endOfLog = self.indexFile:ReadDouble();
+    
+    local buffer = {};
+    for i = 1, itemsToPack do
+        buffer[#buffer + 1] = self.buffer:entryAt(logIndex + i - 1);
     end
-
-    self.dataFile:seek(startOfLog);
-
-    -- "<memory>" is a special name for memory file, both read/write is possible. 
+    local str = commonlib.serialize_compact2(buffer)
     local file = ParaIO.open("<memory>", "w");
     local bytes;
-    if(file:IsValid()) then
-        local dataBytes = endOfLog - startOfLog
-        self.logger.trace("WALSequentialLogStore:packLog>indexBytes:%d, dataBytes:%d", indexBytes, dataBytes)
-        file:WriteDouble(indexBytes)
-        file:WriteDouble(dataBytes)
-       
-        -- index data
-        local indexBuffer = self.indexFile:GetText(indexPosition, indexBytes)
-        assert(#indexBuffer == indexBytes, format("indexBuffer:%d len ~= indexBytes:%d len", #indexBuffer, indexBytes));
-        -- writeBytes(file, indexBuffer)
-        -- file:WriteBytes(indexBytes, {indexBuffer:byte(1, -1)})
-        file:write(indexBuffer, indexBytes)
-
-        -- data
-        local dataBuffer = self.dataFile:GetText(startOfLog, dataBytes);
-        assert(#dataBuffer == dataBytes, format("dataBuffer:%d len ~= dataBytes:%d len", #dataBuffer, dataBytes));
-        -- writeBytes(file, dataBuffer)
-        -- file:WriteBytes(dataBytes, {dataBuffer:byte(1, -1)})
-        file:write(dataBuffer, dataBytes)
-
-
+    if (file:IsValid()) then
+        file:WriteInt(#str)
+        file:WriteString(str)
         bytes = file:GetText(0, -1)
         file:close()
-	 
         -- Compress
-        local data = {content=bytes, method="gzip"};
-        if(NPL.Compress(data)) then
+        local data = {content = bytes, method = "gzip"};
+        if (NPL.Compress(data)) then
             bytes = data.result;
         end
     end
-    openFile(self, "rw")
     
     return bytes;
-
-    -- error handle
-    -- self.logger.error("failed to read files to read data for packing");
 end
 
 --[[
-   Apply the log pack to current log store, starting from index
-   @param index the log index that start applying the logPack, index starts from 1
-   @param logPack
-]]--
+Apply the log pack to current log store, starting from index
+@param index the log index that start applying the logPack, index starts from 1
+@param logPack
+]]
+--
 function WALSequentialLogStore:applyLogPack(logIndex, logPack)
-   self.logger.trace("WALSequentialLogStore:applyLogPack>logIndex:%d, self.startIndex:%d, entriesInStore:%d",
-                     logIndex, self.startIndex, self.entriesInStore);
-   if logIndex < self.startIndex then
+    self.logger.trace("applyLogPack>logIndex:%d, self.startIndex:%d, entriesInStore:%d",
+        logIndex, self.startIndex, self.entriesInStore);
+    if logIndex < self.startIndex then
         return;
     end
-
-    local index = logIndex - self.startIndex + 1;
-
-    local bytes;
-    local data = {content=logPack, method="gzip"};
     
-    if(NPL.Decompress(data)) then
+    local bytes;
+    local data = {content = logPack, method = "gzip"};
+    if (NPL.Decompress(data)) then
         bytes = data.result;
     end
-
-    -- "<memory>" is a special name for memory file, both read/write is possible. 
     local file = ParaIO.open("<memory>", "w");
-    if(file:IsValid()) then
-        file:write(bytes, #bytes)
-        file:seek(0)
-
-        local indexBytes = file:ReadDouble()
-        local dataBytes = file:ReadDouble()
-
-        local indexBuffer = {}
-        local logBuffer = {}
-       
-        -- index data
-        file:ReadBytes(indexBytes, indexBuffer)
-        file:ReadBytes(dataBytes, logBuffer)
-        assert(#indexBuffer == indexBytes, format("indexBuffer:%d len ~= indexBytes:%d len", #indexBuffer, indexBytes));        
-        assert(#logBuffer == dataBytes, format("logBuffer:%d len ~= dataBytes:%d len", #logBuffer, dataBytes));
-        self.logger.trace("WALSequentialLogStore:applyLogPack>indexBytes:%d, dataBytes:%d", indexBytes, dataBytes)
-
-        local indexFilePosition, dataFilePosition;
-        openFile(self, "r")
-        if(index == self.entriesInStore + 1) then
-            indexFilePosition = self.indexFile:GetFileSize();
-            dataFilePosition = self.dataFile:GetFileSize();
-        else
-            indexFilePosition = (index - 1) * DoubleBytes;
-            self.indexFile:seek(indexFilePosition);
-            dataFilePosition = self.indexFile:ReadDouble();
+    if (file:IsValid()) then
+        if type(bytes) == "string" then
+            file:write(bytes, #bytes);
+        elseif type(bytes) == "table" then
+            file:WriteBytes(#bytes, bytes);
         end
-        openFile(self, "rw")
-
-        self.logger.trace("WALSequentialLogStore:applyLogPack>indexFilePosition:%d, dataFilePosition:%d", indexFilePosition, dataFilePosition);
-        self.indexFile:seek(indexFilePosition);
-        self.indexFile:WriteBytes(indexBytes, indexBuffer);
-        self.indexFile:SetFilePointer(indexFilePosition+indexBytes, 0);
-        self.indexFile:SetEndOfFile();
+        file:seek(0)
         
-        self.dataFile:seek(dataFilePosition);
-        self.dataFile:WriteBytes(dataBytes, logBuffer);
-        self.dataFile:SetFilePointer(dataFilePosition+dataBytes, 0);
-        self.dataFile:SetEndOfFile();
-        self.entriesInStore = index - 1 + indexBytes / DoubleBytes;
-
-        -- openFile(self, "r")
-        -- assert(indexFilePosition+indexBytes == self.indexFile:GetFileSize(), format("index pos:%d ~= filesize:%d",indexFilePosition+indexBytes,self.indexFile:GetFileSize()))
-        -- assert(dataFilePosition+dataBytes == self.dataFile:GetFileSize(), format("data pos:%d ~= filesize:%d",dataFilePosition+dataBytes,self.dataFile:GetFileSize()))
-        -- openFile(self, "rw")
-
-        self.buffer:reset(self.entriesInStore > self.bufferSize and self.entriesInStore + self.startIndex - self.bufferSize or self.startIndex);
-        self:fillBuffer();
-        file:close()
+        local n = file:ReadInt();
+        local str = file:ReadString(n)
+        -- print(str)
+        local buffer = commonlib.LoadTableFromString(str);
+        
+        for i, v in ipairs(buffer) do
+            self.buffer:writeAt(logIndex + i - 1, v);
+        end
     end
 
-    -- error handle
-    -- self.logger.error("failed to write files to unpack logs for data");
+-- self.buffer:reset(self.startIndex);
 end
 
 --[[
-   Compact the log store by removing all log entries including the log at the lastLogIndex
-   @param lastLogIndex
-   @return compact successfully or not
-]]--
+Compact the log store by removing all log entries including the log at the lastLogIndex
+@param lastLogIndex
+@return compact successfully or not
+]]
+--
 function WALSequentialLogStore:compact(lastLogIndex)
     if lastLogIndex < self.startIndex then
         return;
     end
-
-    self:backup();
+    
     local lastIndex = lastLogIndex - self.startIndex;
-    if(lastLogIndex >= self:getFirstAvailableIndex() - 1) then
-        self.indexFile:seek(0)
-        self.indexFile:SetEndOfFile();
-        self.dataFile:seek(0);
-        self.dataFile:SetEndOfFile();
-        self.startIndexFile:seek(0);
-        self.startIndexFile:WriteDouble(lastLogIndex + 1);
+    if (lastLogIndex >= self:getFirstAvailableIndex() - 1) then
         self.startIndex = lastLogIndex + 1;
         self.entriesInStore = 0;
         self.buffer:reset(lastLogIndex + 1);
-        return true;
     else
-        openFile(self, "r")
-        local dataPosition = -1;
-        local indexPosition = DoubleBytes * (lastIndex + 1);
-        self.indexFile:seek(indexPosition);
-        dataPosition = self.indexFile:ReadDouble()
-        local indexFileNewLength = self.indexFile:GetFileSize() - indexPosition;
-        local dataFileNewLength = self.dataFile:GetFileSize() - dataPosition;
-
-        openFile(self, "rw")
-
-        -- copy the log data
-        -- data file
-        local backupFile = ParaIO.open(self.backupDataFileName, "r");
-        assert(backupFile:IsValid(), "dataFile not Valid")
-
-        -- we don't have an channel, so this is inefficient and ugly
-        backupFile:seek(dataPosition);
-        local data = {}
-        backupFile:ReadBytes(dataFileNewLength, data)
-        self.dataFile:seek(0)
-        self.dataFile:WriteBytes(dataFileNewLength, data)
-        self.dataFile:SetEndOfFile()
-        backupFile:close();
-
-        -- copy the index data
-        -- index file
-        backupFile = ParaIO.open(self.backupIndexFileName, "r");
-        assert(backupFile:IsValid(), "backupFile not Valid")
-
-        
-        backupFile:seek(indexPosition);
-        self.indexFile:seek(0);
-        for  i = 1, indexFileNewLength / DoubleBytes do
-            self.indexFile:WriteDouble(backupFile:ReadDouble() - dataPosition);
-        end
-
-        self.indexFile:SetEndOfFile();
-        backupFile:close();
-
-        -- save the starting index
-        self.startIndexFile:seek(0);
-        self.startIndexFile:WriteDouble(lastLogIndex + 1);
         self.entriesInStore = self.entriesInStore - (lastLogIndex - self.startIndex + 1);
         self.startIndex = lastLogIndex + 1;
-        self.buffer:reset(self.entriesInStore > self.bufferSize and self.entriesInStore + self.startIndex - self.bufferSize or self.startIndex);
-        self:fillBuffer();
-        return true;
+        self.buffer:reset(self.startIndex);
     end
-
-    self.logger.error("fail to compact the logs due to error");
-    self:restore();
-    return false;
-end
-
-function WALSequentialLogStore:fillBuffer()
-    openFile(self, "r")
-    local startIndex = self.buffer:firstIndex();
-    local indexFileSize = self.indexFile:GetFileSize();
-    if(indexFileSize > 0) then
-        local indexPosition = (startIndex - self.startIndex) * DoubleBytes;
-        self.indexFile:seek(indexPosition);
-        local dataStart = self.indexFile:ReadDouble();
-        self.dataFile:seek(dataStart);
-        while(self.indexFile:getpos() < indexFileSize) do
-            local dataEnd = self.indexFile:ReadDouble();
-            self.logger.trace("WALSequentialLogStore:fillBuffer>dataStart:%d, dataEnd:%d", dataStart, dataEnd)
-            local entry = self:readEntry(dataEnd - dataStart);
-            -- util.table_print(entry)
-            self.buffer:append(entry);
-            dataStart = dataEnd;
-        end
-        self.logger.trace("WALSequentialLogStore:fillBuffer>dataStart:%d, dataEnd:%d", dataStart, self.dataFile:GetFileSize())
-        local entry = self:readEntry(self.dataFile:GetFileSize() - dataStart);
-        self.buffer:append(entry);
-    end
-    -- self.logger.trace("WALSequentialLogStore:fillBuffer>buffer firstIndex:%d, entries:%d", self.buffer:firstIndex(), self.buffer:bufferSize())
-    openFile(self, "rw")
-end
-
-
-function WALSequentialLogStore:restore()
-    self:closeFiles();
-
-    if not (ParaIO.CopyFile(self.backupIndexFileName, self.indexFileName, true) and
-        ParaIO.CopyFile(self.backupDataFileName, self.dataFileName, true) and
-        ParaIO.CopyFile(self.backupStartIndexFileName, self.startIndexFileName, true)) then
-        -- this is fatal...
-        self.logger.fatal("cannot restore from failure, please manually restore the log files");
-    end
-    openFile(self, "rw")
-end
-
-function WALSequentialLogStore:backup()
-    self:close()
-    --decide not to use ParaIO.BackupFile
-    ParaIO.DeleteFile(self.backupDataFileName)
-    ParaIO.DeleteFile(self.backupIndexFileName)
-    ParaIO.DeleteFile(self.backupStartIndexFileName)
-
-    if not (ParaIO.CopyFile(self.indexFileName, self.backupIndexFileName, true) and
-        ParaIO.CopyFile(self.dataFileName, self.backupDataFileName, true) and
-        ParaIO.CopyFile(self.startIndexFileName, self.backupStartIndexFileName, true)) then
-        self.logger.error("failed to create a backup folder")
-    end
-
-    openFile(self, "rw")
+    
+    return true;
 end
 
 
 function WALSequentialLogStore:readEntry(size)
-    local term = self.dataFile:ReadDouble();
-    local valueTypeByte = {}
-    self.dataFile:ReadBytes(1, valueTypeByte);
-    local valueType = valueTypeByte[1]
-    local valueBytes = {}
-    -- print(format("WALSequentialLogStore:readEntry>%d", size-DoubleBytes-1))
-    assert(size-DoubleBytes-1 > 0, "size error")
-    self.dataFile:ReadBytes(size-DoubleBytes-1, valueBytes);
-    -- util.table_print(valueBytes)
-    local value = string.char(unpack(valueBytes))
-    -- local value = self.dataFile:ReadBytes(size-DoubleBytes-1, nil);
-    return LogEntry:new(term, value, valueType);
+-- need this?
+-- read Entry from WAL
 end
 
-function WALSequentialLogStore:closeFiles()
-    self.indexFile:close()
-    self.dataFile:close()
-    self.startIndexFile:close()
-end
 function WALSequentialLogStore:close()
-    self:closeFiles()
-    self.prevMode = nil;
-end
-
-function openFile(logStore, mode)
-    if mode == logStore.prevMode then
-        return;
-    else
-        logStore.prevMode = mode
-    end
-    if logStore.indexFile and logStore.dataFile and logStore.startIndexFile then
-        logStore:closeFiles()
-    end
-    -- index file
-    logStore.indexFile = ParaIO.open(logStore.indexFileName, mode);
-    -- assert(logStore.indexFile:IsValid(), "indexFile not Valid")
-
-    -- data file
-    logStore.dataFile = ParaIO.open(logStore.dataFileName, mode);
-    -- assert(logStore.dataFile:IsValid(), "dataFile not Valid")
-
-    -- startIndex file
-    logStore.startIndexFile = ParaIO.open(logStore.startIndexFileName, mode);
-    -- assert(logStore.startIndexFile:IsValid(), "startIndexFile not Valid")
-
-    local valid = logStore.indexFile:IsValid() and logStore.dataFile:IsValid() and logStore.startIndexFile:IsValid();
-    if not valid then
-        mode = "rw"
-        return openFile(logStore, mode)
-    end
-end
-
-function writeBytes(file, indexBuffer)
-    if #indexBuffer > 1024 then
-        local start_pos = 1
-        local end_pos = 1024
-        while start_pos < #indexBuffer do
-            file:WriteBytes(end_pos - start_pos + 1, {indexBuffer:byte(start_pos, end_pos)})
-            start_pos = end_pos + 1;
-            end_pos = end_pos + 1024;
-        end
-    else
-        -- file:WriteBytes(#indexBuffer, {indexBuffer:byte(1, -1)})
-        file:write(indexBuffer, indexBuffer)
-    end
+    self.db.raftLog:close();
 end

--- a/npl_mod/Raft/WALSequentialLogStore.lua
+++ b/npl_mod/Raft/WALSequentialLogStore.lua
@@ -320,5 +320,5 @@ function WALSequentialLogStore:readEntry(size)
 end
 
 function WALSequentialLogStore:close()
-    self.db.raftLog:close();
+    -- self.db.raftLog:close();
 end

--- a/npl_mod/Raft/WALSequentialLogStore.lua
+++ b/npl_mod/Raft/WALSequentialLogStore.lua
@@ -1,0 +1,590 @@
+--[[
+Title: 
+Author: liuluheng
+Date: 2017.03.25
+Desc: 
+
+NPL file API dose not support u GetFileSize in "rw" mode(and variou things like this),
+so the code is a bit ugly :(
+
+------------------------------------------------------------
+NPL.load("(gl)npl_mod/Raft/WALSequentialLogStore.lua");
+local WALSequentialLogStore = commonlib.gettable("Raft.WALSequentialLogStore");
+------------------------------------------------------------
+]]--
+NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
+local util = commonlib.gettable("System.Compiler.lib.util")
+NPL.load("(gl)npl_mod/Raft/LogEntry.lua");
+local LogEntry = commonlib.gettable("Raft.LogEntry");
+NPL.load("(gl)npl_mod/Raft/LogBuffer.lua");
+local LogBuffer = commonlib.gettable("Raft.LogBuffer");
+
+local LoggerFactory = NPL.load("(gl)npl_mod/Raft/LoggerFactory.lua");
+
+local WALSequentialLogStore = commonlib.gettable("Raft.WALSequentialLogStore");
+
+local BUFFER_SIZE = 1000;
+
+local openFile;
+
+function WALSequentialLogStore:new(logContainer) 
+    local o = {
+        logContainer = logContainer,
+        logger = LoggerFactory.getLogger("WALSequentialLogStore"),
+        zeroEntry = LogEntry:new(),
+        bufferSize = BUFFER_SIZE,
+    };
+    setmetatable(o, self);
+
+    -- always start from 1, 0, emptyBuffer
+    o.startIndex = 1;
+    o.entriesInStore = 0;
+    o.buffer = LogBuffer:new(o.startIndex, o.bufferSize);
+
+    return o;
+end
+
+function WALSequentialLogStore:__index(name)
+    return rawget(self, name) or WALSequentialLogStore[name];
+end
+
+function WALSequentialLogStore:__tostring()
+    return util.table_tostring(self)
+end
+
+--[[
+   The first available index of the store, starts with 1
+   @return value >= 1
+]]--
+function WALSequentialLogStore:getFirstAvailableIndex()
+    return self.entriesInStore + self.startIndex;
+end
+
+--[[
+   The start index of the log store, at the very beginning, it must be 1
+   however, after some compact actions, this could be anything greater or equals to one
+   @return start index of the log store
+]]--
+function WALSequentialLogStore:getStartIndex()
+    return self.startIndex
+end
+
+--[[
+   The last log entry in store
+   @return a dummy constant entry with value set to null and term set to zero if no log entry in store
+]]--
+function WALSequentialLogStore:getLastLogEntry()
+    local lastEntry = self.buffer:lastEntry();
+    return (lastEntry == nil and self.zeroEntry) or lastEntry;
+end
+
+--[[
+   Appends a log entry to store
+   @param logEntry
+   @return the last appended log index
+]]--
+function WALSequentialLogStore:append(logEntry)
+    -- we do not touch disk
+    self.entriesInStore = self.entriesInStore + 1;
+    self.buffer:append(logEntry);
+    return self.entriesInStore + self.startIndex - 1;
+end
+
+--[[
+   Over writes a log entry at index of {@code index}
+   @param index a value < {@code this.getFirstAvailableIndex()}, and starts from 1
+   @param logEntry
+]]--
+function WALSequentialLogStore:writeAt(logIndex, logEntry)
+    if logIndex < self.startIndex then
+        return;
+    end
+
+    openFile(self, "r")
+
+    local index = logIndex - self.startIndex
+    -- find the positions for index and data files
+    local dataPosition = self.dataFile:GetFileSize();
+    local indexPosition = (index - 1) * DoubleBytes;
+    if(indexPosition < self.indexFile:GetFileSize()) then
+        self.indexFile:seek(indexPosition);
+        dataPosition = self.indexFile:ReadDouble();
+    end
+
+    local dataFileSize = self.dataFile:GetFileSize();
+    local indexFileSize = self.indexFile:GetFileSize();
+
+    openFile(self, "rw")
+    -- write the data at the specified position
+    self.indexFile:seek(indexPosition);
+    self.dataFile:seek(dataPosition);
+    self.indexFile:WriteDouble(dataPosition);
+    self.dataFile:WriteDouble(logEntry.term);
+    self.dataFile:WriteBytes(1, {logEntry.valueType});
+    -- self.dataFile:WriteBytes(#logEntry.value, {logEntry.value:byte(1, -1)});
+    self.dataFile:write(logEntry.value, #logEntry.value);
+
+    -- trim the files if necessary
+    if(indexFileSize > self.indexFile:getpos()) then
+        self.indexFile:SetEndOfFile();
+    end
+
+    if(dataFileSize > self.dataFile:getpos()) then
+        self.dataFile:SetEndOfFile();
+    end
+
+    if(index <= self.entriesInStore) then
+        self.buffer:trim(logIndex);
+    end
+    
+    self.buffer:append(logEntry);
+    self.entriesInStore = index;
+end
+
+--[[
+   Get log entries with index between {@code start} and {@code end}
+   @param start the start index of log entries
+   @param end the end index of log entries (exclusive)
+   @return the log entries between [start, end)
+]]--
+function WALSequentialLogStore:getLogEntries(startIndex, endIndex)
+    self.logger.trace("getLogEntries:startIndex:%d, endIndex:%d, self.startIndex:%d, self.entriesInStore:%d",
+                       startIndex, endIndex, self.startIndex, self.entriesInStore)
+    if startIndex < self.startIndex then
+        return;
+    end
+
+    -- start and adjustedEnd are zero based, targetEndIndex is this.startIndex based
+    local start = startIndex - self.startIndex;
+    local adjustedEnd = endIndex - self.startIndex;
+    adjustedEnd = (adjustedEnd > self.entriesInStore and self.entriesInStore) or adjustedEnd;
+    local targetEndIndex = (endIndex > self.entriesInStore + self.startIndex + 1 and self.entriesInStore + self.startIndex + 1) or endIndex;
+
+    local entries = {}
+    if adjustedEnd - start == 0 then
+        return entries
+    end
+
+    self.logger.trace("getLogEntries:pre fill entries len:%d", #entries)
+    -- fill with buffer
+    local bufferFirstIndex = self.buffer:fill(startIndex, targetEndIndex, entries);
+    
+    -- Assumption: buffer.lastIndex() == this.entriesInStore + this.startIndex
+    -- (Yes, for sure, we need to enforce this assumption to be true)
+    if(startIndex < bufferFirstIndex) then
+        -- in this case, we need to read from store file
+        local fileEntries = {}
+        local endi = bufferFirstIndex - self.startIndex;
+
+        openFile(self, "r")
+
+        self.indexFile:seek(start * DoubleBytes)
+        self.logger.trace("getLogEntries: start bytes:%d, indexfile pos:%d",  start * DoubleBytes, self.indexFile:getpos())
+        local dataStart = self.indexFile:ReadDouble();
+        for i = 1, (endi - start) do
+            local dataEnd = self.indexFile:ReadDouble();
+            local dataSize = dataEnd - dataStart;
+            self.dataFile:seek(dataStart);
+            -- self.logger.trace("getLogEntries: dataStart:%d, dataEnd:%d, indexfile pos:%d, datafile pos:%d", dataStart, dataEnd, self.indexFile:getpos(), self.dataFile:getpos());
+            -- here we should use i to index
+            fileEntries[i] = self:readEntry(dataSize);
+            dataStart = dataEnd;
+        end
+        for i=1,#entries do
+            fileEntries[#fileEntries+1] = entries[i];
+        end
+        entries = fileEntries
+
+
+        openFile(self, "rw")
+    end
+
+    return entries;
+end
+
+--[[
+   Gets the log entry at the specified index
+   @param index starts from 1
+   @return the log entry or null if index >= {@code this.getFirstAvailableIndex()}
+]]--
+function WALSequentialLogStore:getLogEntryAt(logIndex)
+    self.logger.trace("WALSequentialLogStore:getLogEntryAt>logIndex:%d, self.startIndex:%d, self.entriesInStore:%d",
+                       logIndex, self.startIndex, self.entriesInStore)
+    if logIndex < self.startIndex then
+        return;
+    end
+
+    local index = logIndex - self.startIndex + 1;
+    if(index > self.entriesInStore) then
+        return;
+    end
+
+    local entry = self.buffer:entryAt(logIndex);
+    if(entry ~= nil) then
+        return entry;
+    end
+
+    openFile(self, "r")
+    local indexPosition = (index - 1) * DoubleBytes;
+    self.indexFile:seek(indexPosition);
+    local dataPosition = self.indexFile:ReadDouble();
+    local endDataPosition = self.indexFile:ReadDouble();
+    self.dataFile:seek(dataPosition);
+    return self:readEntry(endDataPosition - dataPosition)
+ end
+
+--[[
+   Pack {@code itemsToPack} log items starts from {@code index}
+   @param index
+   @param itemsToPack
+   @return log pack
+]]--
+function WALSequentialLogStore:packLog(logIndex, itemsToPack)
+    self.logger.trace("WALSequentialLogStore:packLog>logIndex:%d, itemsToPack:%d, self.startIndex:%d, entriesInStore:%d",
+                       logIndex, itemsToPack, self.startIndex, self.entriesInStore);
+    if logIndex < self.startIndex then
+        return;
+    end
+
+    local index = logIndex - self.startIndex + 1;
+    if(index > self.entriesInStore) then
+        return {};
+    end
+
+    openFile(self, "r")
+
+    local endIndex = math.min(index + itemsToPack, self.entriesInStore + 1);
+    local readToEnd = (endIndex == self.entriesInStore + 1);
+    local indexPosition = (index - 1) * DoubleBytes;
+    self.indexFile:seek(indexPosition);
+
+    local startOfLog = self.indexFile:ReadDouble();
+    local endOfLog = self.dataFile:GetFileSize();
+    local indexBytes = DoubleBytes * (endIndex - index)
+    if(not readToEnd) then
+        -- self.indexFile:seekRelative(indexBytes)
+        self.indexFile:seek(indexPosition + indexBytes)
+        endOfLog = self.indexFile:ReadDouble();
+    end
+
+    self.dataFile:seek(startOfLog);
+
+    -- "<memory>" is a special name for memory file, both read/write is possible. 
+    local file = ParaIO.open("<memory>", "w");
+    local bytes;
+    if(file:IsValid()) then
+        local dataBytes = endOfLog - startOfLog
+        self.logger.trace("WALSequentialLogStore:packLog>indexBytes:%d, dataBytes:%d", indexBytes, dataBytes)
+        file:WriteDouble(indexBytes)
+        file:WriteDouble(dataBytes)
+       
+        -- index data
+        local indexBuffer = self.indexFile:GetText(indexPosition, indexBytes)
+        assert(#indexBuffer == indexBytes, format("indexBuffer:%d len ~= indexBytes:%d len", #indexBuffer, indexBytes));
+        -- writeBytes(file, indexBuffer)
+        -- file:WriteBytes(indexBytes, {indexBuffer:byte(1, -1)})
+        file:write(indexBuffer, indexBytes)
+
+        -- data
+        local dataBuffer = self.dataFile:GetText(startOfLog, dataBytes);
+        assert(#dataBuffer == dataBytes, format("dataBuffer:%d len ~= dataBytes:%d len", #dataBuffer, dataBytes));
+        -- writeBytes(file, dataBuffer)
+        -- file:WriteBytes(dataBytes, {dataBuffer:byte(1, -1)})
+        file:write(dataBuffer, dataBytes)
+
+
+        bytes = file:GetText(0, -1)
+        file:close()
+	 
+        -- Compress
+        local data = {content=bytes, method="gzip"};
+        if(NPL.Compress(data)) then
+            bytes = data.result;
+        end
+    end
+    openFile(self, "rw")
+    
+    return bytes;
+
+    -- error handle
+    -- self.logger.error("failed to read files to read data for packing");
+end
+
+--[[
+   Apply the log pack to current log store, starting from index
+   @param index the log index that start applying the logPack, index starts from 1
+   @param logPack
+]]--
+function WALSequentialLogStore:applyLogPack(logIndex, logPack)
+   self.logger.trace("WALSequentialLogStore:applyLogPack>logIndex:%d, self.startIndex:%d, entriesInStore:%d",
+                     logIndex, self.startIndex, self.entriesInStore);
+   if logIndex < self.startIndex then
+        return;
+    end
+
+    local index = logIndex - self.startIndex + 1;
+
+    local bytes;
+    local data = {content=logPack, method="gzip"};
+    
+    if(NPL.Decompress(data)) then
+        bytes = data.result;
+    end
+
+    -- "<memory>" is a special name for memory file, both read/write is possible. 
+    local file = ParaIO.open("<memory>", "w");
+    if(file:IsValid()) then
+        file:write(bytes, #bytes)
+        file:seek(0)
+
+        local indexBytes = file:ReadDouble()
+        local dataBytes = file:ReadDouble()
+
+        local indexBuffer = {}
+        local logBuffer = {}
+       
+        -- index data
+        file:ReadBytes(indexBytes, indexBuffer)
+        file:ReadBytes(dataBytes, logBuffer)
+        assert(#indexBuffer == indexBytes, format("indexBuffer:%d len ~= indexBytes:%d len", #indexBuffer, indexBytes));        
+        assert(#logBuffer == dataBytes, format("logBuffer:%d len ~= dataBytes:%d len", #logBuffer, dataBytes));
+        self.logger.trace("WALSequentialLogStore:applyLogPack>indexBytes:%d, dataBytes:%d", indexBytes, dataBytes)
+
+        local indexFilePosition, dataFilePosition;
+        openFile(self, "r")
+        if(index == self.entriesInStore + 1) then
+            indexFilePosition = self.indexFile:GetFileSize();
+            dataFilePosition = self.dataFile:GetFileSize();
+        else
+            indexFilePosition = (index - 1) * DoubleBytes;
+            self.indexFile:seek(indexFilePosition);
+            dataFilePosition = self.indexFile:ReadDouble();
+        end
+        openFile(self, "rw")
+
+        self.logger.trace("WALSequentialLogStore:applyLogPack>indexFilePosition:%d, dataFilePosition:%d", indexFilePosition, dataFilePosition);
+        self.indexFile:seek(indexFilePosition);
+        self.indexFile:WriteBytes(indexBytes, indexBuffer);
+        self.indexFile:SetFilePointer(indexFilePosition+indexBytes, 0);
+        self.indexFile:SetEndOfFile();
+        
+        self.dataFile:seek(dataFilePosition);
+        self.dataFile:WriteBytes(dataBytes, logBuffer);
+        self.dataFile:SetFilePointer(dataFilePosition+dataBytes, 0);
+        self.dataFile:SetEndOfFile();
+        self.entriesInStore = index - 1 + indexBytes / DoubleBytes;
+
+        -- openFile(self, "r")
+        -- assert(indexFilePosition+indexBytes == self.indexFile:GetFileSize(), format("index pos:%d ~= filesize:%d",indexFilePosition+indexBytes,self.indexFile:GetFileSize()))
+        -- assert(dataFilePosition+dataBytes == self.dataFile:GetFileSize(), format("data pos:%d ~= filesize:%d",dataFilePosition+dataBytes,self.dataFile:GetFileSize()))
+        -- openFile(self, "rw")
+
+        self.buffer:reset(self.entriesInStore > self.bufferSize and self.entriesInStore + self.startIndex - self.bufferSize or self.startIndex);
+        self:fillBuffer();
+        file:close()
+    end
+
+    -- error handle
+    -- self.logger.error("failed to write files to unpack logs for data");
+end
+
+--[[
+   Compact the log store by removing all log entries including the log at the lastLogIndex
+   @param lastLogIndex
+   @return compact successfully or not
+]]--
+function WALSequentialLogStore:compact(lastLogIndex)
+    if lastLogIndex < self.startIndex then
+        return;
+    end
+
+    self:backup();
+    local lastIndex = lastLogIndex - self.startIndex;
+    if(lastLogIndex >= self:getFirstAvailableIndex() - 1) then
+        self.indexFile:seek(0)
+        self.indexFile:SetEndOfFile();
+        self.dataFile:seek(0);
+        self.dataFile:SetEndOfFile();
+        self.startIndexFile:seek(0);
+        self.startIndexFile:WriteDouble(lastLogIndex + 1);
+        self.startIndex = lastLogIndex + 1;
+        self.entriesInStore = 0;
+        self.buffer:reset(lastLogIndex + 1);
+        return true;
+    else
+        openFile(self, "r")
+        local dataPosition = -1;
+        local indexPosition = DoubleBytes * (lastIndex + 1);
+        self.indexFile:seek(indexPosition);
+        dataPosition = self.indexFile:ReadDouble()
+        local indexFileNewLength = self.indexFile:GetFileSize() - indexPosition;
+        local dataFileNewLength = self.dataFile:GetFileSize() - dataPosition;
+
+        openFile(self, "rw")
+
+        -- copy the log data
+        -- data file
+        local backupFile = ParaIO.open(self.backupDataFileName, "r");
+        assert(backupFile:IsValid(), "dataFile not Valid")
+
+        -- we don't have an channel, so this is inefficient and ugly
+        backupFile:seek(dataPosition);
+        local data = {}
+        backupFile:ReadBytes(dataFileNewLength, data)
+        self.dataFile:seek(0)
+        self.dataFile:WriteBytes(dataFileNewLength, data)
+        self.dataFile:SetEndOfFile()
+        backupFile:close();
+
+        -- copy the index data
+        -- index file
+        backupFile = ParaIO.open(self.backupIndexFileName, "r");
+        assert(backupFile:IsValid(), "backupFile not Valid")
+
+        
+        backupFile:seek(indexPosition);
+        self.indexFile:seek(0);
+        for  i = 1, indexFileNewLength / DoubleBytes do
+            self.indexFile:WriteDouble(backupFile:ReadDouble() - dataPosition);
+        end
+
+        self.indexFile:SetEndOfFile();
+        backupFile:close();
+
+        -- save the starting index
+        self.startIndexFile:seek(0);
+        self.startIndexFile:WriteDouble(lastLogIndex + 1);
+        self.entriesInStore = self.entriesInStore - (lastLogIndex - self.startIndex + 1);
+        self.startIndex = lastLogIndex + 1;
+        self.buffer:reset(self.entriesInStore > self.bufferSize and self.entriesInStore + self.startIndex - self.bufferSize or self.startIndex);
+        self:fillBuffer();
+        return true;
+    end
+
+    self.logger.error("fail to compact the logs due to error");
+    self:restore();
+    return false;
+end
+
+function WALSequentialLogStore:fillBuffer()
+    openFile(self, "r")
+    local startIndex = self.buffer:firstIndex();
+    local indexFileSize = self.indexFile:GetFileSize();
+    if(indexFileSize > 0) then
+        local indexPosition = (startIndex - self.startIndex) * DoubleBytes;
+        self.indexFile:seek(indexPosition);
+        local dataStart = self.indexFile:ReadDouble();
+        self.dataFile:seek(dataStart);
+        while(self.indexFile:getpos() < indexFileSize) do
+            local dataEnd = self.indexFile:ReadDouble();
+            self.logger.trace("WALSequentialLogStore:fillBuffer>dataStart:%d, dataEnd:%d", dataStart, dataEnd)
+            local entry = self:readEntry(dataEnd - dataStart);
+            -- util.table_print(entry)
+            self.buffer:append(entry);
+            dataStart = dataEnd;
+        end
+        self.logger.trace("WALSequentialLogStore:fillBuffer>dataStart:%d, dataEnd:%d", dataStart, self.dataFile:GetFileSize())
+        local entry = self:readEntry(self.dataFile:GetFileSize() - dataStart);
+        self.buffer:append(entry);
+    end
+    -- self.logger.trace("WALSequentialLogStore:fillBuffer>buffer firstIndex:%d, entries:%d", self.buffer:firstIndex(), self.buffer:bufferSize())
+    openFile(self, "rw")
+end
+
+
+function WALSequentialLogStore:restore()
+    self:closeFiles();
+
+    if not (ParaIO.CopyFile(self.backupIndexFileName, self.indexFileName, true) and
+        ParaIO.CopyFile(self.backupDataFileName, self.dataFileName, true) and
+        ParaIO.CopyFile(self.backupStartIndexFileName, self.startIndexFileName, true)) then
+        -- this is fatal...
+        self.logger.fatal("cannot restore from failure, please manually restore the log files");
+    end
+    openFile(self, "rw")
+end
+
+function WALSequentialLogStore:backup()
+    self:close()
+    --decide not to use ParaIO.BackupFile
+    ParaIO.DeleteFile(self.backupDataFileName)
+    ParaIO.DeleteFile(self.backupIndexFileName)
+    ParaIO.DeleteFile(self.backupStartIndexFileName)
+
+    if not (ParaIO.CopyFile(self.indexFileName, self.backupIndexFileName, true) and
+        ParaIO.CopyFile(self.dataFileName, self.backupDataFileName, true) and
+        ParaIO.CopyFile(self.startIndexFileName, self.backupStartIndexFileName, true)) then
+        self.logger.error("failed to create a backup folder")
+    end
+
+    openFile(self, "rw")
+end
+
+
+function WALSequentialLogStore:readEntry(size)
+    local term = self.dataFile:ReadDouble();
+    local valueTypeByte = {}
+    self.dataFile:ReadBytes(1, valueTypeByte);
+    local valueType = valueTypeByte[1]
+    local valueBytes = {}
+    -- print(format("WALSequentialLogStore:readEntry>%d", size-DoubleBytes-1))
+    assert(size-DoubleBytes-1 > 0, "size error")
+    self.dataFile:ReadBytes(size-DoubleBytes-1, valueBytes);
+    -- util.table_print(valueBytes)
+    local value = string.char(unpack(valueBytes))
+    -- local value = self.dataFile:ReadBytes(size-DoubleBytes-1, nil);
+    return LogEntry:new(term, value, valueType);
+end
+
+function WALSequentialLogStore:closeFiles()
+    self.indexFile:close()
+    self.dataFile:close()
+    self.startIndexFile:close()
+end
+function WALSequentialLogStore:close()
+    self:closeFiles()
+    self.prevMode = nil;
+end
+
+function openFile(logStore, mode)
+    if mode == logStore.prevMode then
+        return;
+    else
+        logStore.prevMode = mode
+    end
+    if logStore.indexFile and logStore.dataFile and logStore.startIndexFile then
+        logStore:closeFiles()
+    end
+    -- index file
+    logStore.indexFile = ParaIO.open(logStore.indexFileName, mode);
+    -- assert(logStore.indexFile:IsValid(), "indexFile not Valid")
+
+    -- data file
+    logStore.dataFile = ParaIO.open(logStore.dataFileName, mode);
+    -- assert(logStore.dataFile:IsValid(), "dataFile not Valid")
+
+    -- startIndex file
+    logStore.startIndexFile = ParaIO.open(logStore.startIndexFileName, mode);
+    -- assert(logStore.startIndexFile:IsValid(), "startIndexFile not Valid")
+
+    local valid = logStore.indexFile:IsValid() and logStore.dataFile:IsValid() and logStore.startIndexFile:IsValid();
+    if not valid then
+        mode = "rw"
+        return openFile(logStore, mode)
+    end
+end
+
+function writeBytes(file, indexBuffer)
+    if #indexBuffer > 1024 then
+        local start_pos = 1
+        local end_pos = 1024
+        while start_pos < #indexBuffer do
+            file:WriteBytes(end_pos - start_pos + 1, {indexBuffer:byte(start_pos, end_pos)})
+            start_pos = end_pos + 1;
+            end_pos = end_pos + 1024;
+        end
+    else
+        -- file:WriteBytes(#indexBuffer, {indexBuffer:byte(1, -1)})
+        file:write(indexBuffer, indexBuffer)
+    end
+end

--- a/npl_mod/Raft/test/TestFileBasedServerStateManager.lua
+++ b/npl_mod/Raft/test/TestFileBasedServerStateManager.lua
@@ -3,11 +3,11 @@ Title:
 Author: liuluheng
 Date: 2017.04.05
 Desc: 
-TEST ServerStateManager
+TEST FileBasedServerStateManager
 ------------------------------------------------------------
 NPL.load("(gl)script/ide/UnitTest/luaunit.lua");
-NPL.load("(gl)npl_mod/Raft/test/TestServerStateManager.lua");
-LuaUnit:run('TestServerStateManager') 
+NPL.load("(gl)npl_mod/Raft/test/TestFileBasedServerStateManager.lua");
+LuaUnit:run('TestFileBasedServerStateManager') 
 ------------------------------------------------------------
 ]]--
 
@@ -17,8 +17,8 @@ NPL.load("(gl)npl_mod/Raft/ClusterServer.lua");
 local ClusterServer = commonlib.gettable("Raft.ClusterServer");
 NPL.load("(gl)npl_mod/Raft/ServerState.lua");
 local ServerState = commonlib.gettable("Raft.ServerState");
-NPL.load("(gl)npl_mod/Raft/ServerStateManager.lua");
-local ServerStateManager = commonlib.gettable("Raft.ServerStateManager");
+NPL.load("(gl)npl_mod/Raft/FileBasedServerStateManager.lua");
+local FileBasedServerStateManager = commonlib.gettable("Raft.FileBasedServerStateManager");
 
 
 local MAX_LONG = 2^63 - 1;
@@ -29,9 +29,9 @@ local removeTestFiles, randomConfiguration, assertConfigEquals;
 local assertTrue = assert
 
 
-TestServerStateManager = {}
+TestFileBasedServerStateManager = {}
 
-function TestServerStateManager:testStateManager()
+function TestFileBasedServerStateManager:testStateManager()
     local container = "temp/logstore/";
     -- commonlib.Files.TouchFolder(container); -- this not works
     removeTestFiles(container);
@@ -50,7 +50,7 @@ function TestServerStateManager:testStateManager()
         self.logger.error("%s path error", filename)
     end
 
-    local manager = ServerStateManager:new(container);
+    local manager = FileBasedServerStateManager:new(container);
     assertTrue(manager.logStore ~= nil);
     assertTrue(manager:readState() == nil);
     local rounds = 50 + math.random(100);

--- a/npl_mod/Raft/test/TestSqliteBasedServerStateManager.lua
+++ b/npl_mod/Raft/test/TestSqliteBasedServerStateManager.lua
@@ -1,0 +1,121 @@
+--[[
+Title:
+Author: liuluheng
+Date: 2017.04.05
+Desc:
+TEST SqliteBasedServerStateManager
+------------------------------------------------------------
+NPL.load("(gl)script/ide/UnitTest/luaunit.lua");
+NPL.load("(gl)npl_mod/Raft/test/TestSqliteBasedServerStateManager.lua");
+LuaUnit:run('TestSqliteBasedServerStateManager')
+------------------------------------------------------------
+]]
+--
+NPL.load("(gl)npl_mod/Raft/ClusterConfiguration.lua");
+local ClusterConfiguration = commonlib.gettable("Raft.ClusterConfiguration");
+NPL.load("(gl)npl_mod/Raft/ClusterServer.lua");
+local ClusterServer = commonlib.gettable("Raft.ClusterServer");
+NPL.load("(gl)npl_mod/Raft/ServerState.lua");
+local ServerState = commonlib.gettable("Raft.ServerState");
+NPL.load("(gl)npl_mod/Raft/SqliteBasedServerStateManager.lua");
+local SqliteBasedServerStateManager = commonlib.gettable("Raft.SqliteBasedServerStateManager");
+
+
+local MAX_LONG = 2 ^ 63 - 1;
+local MAX_INT = 2 ^ 31 - 1;
+
+local removeTestFiles, randomConfiguration, assertConfigEquals;
+
+local assertTrue = assert
+
+
+TestSqliteBasedServerStateManager = {}
+
+function TestSqliteBasedServerStateManager:testStateManager()
+    local container = "temp/logstore/";
+    -- commonlib.Files.TouchFolder(container); -- this not works
+    removeTestFiles(container);
+    ParaIO.CreateDirectory(container);
+    
+    local serverId = math.random(MAX_INT);
+    local config = randomConfiguration();
+    
+    local data = commonlib.Json.Encode(config);
+    local filename = container .. "cluster.json";
+    local clusterConfigFile = ParaIO.open(filename, "w");
+    if clusterConfigFile:IsValid() then
+        clusterConfigFile:WriteString(data);
+        clusterConfigFile:close();
+    else
+        self.logger.error("%s path error", filename)
+    end
+    
+    local filename = container .. "config.properties";
+    local serverIdConfigFile = ParaIO.open(filename, "w");
+    if serverIdConfigFile:IsValid() then
+        serverIdConfigFile:WriteString("server.id=1");
+        serverIdConfigFile:close();
+    else
+        self.logger.error("%s path error", filename)
+    end
+    
+    local manager = SqliteBasedServerStateManager:new(container);
+    assertTrue(manager.logStore ~= nil);
+    assertTrue(manager:readState() == nil);
+    local rounds = 50 + math.random(100);
+    while (rounds > 0) do
+        local state = ServerState:new(math.random(MAX_LONG), math.random(MAX_LONG), math.random(MAX_INT));
+        manager:persistState(state);
+        local state1 = manager:readState();
+        assertTrue(state1 ~= nil);
+        assertEquals(state.term, state1.term);
+        assertEquals(state.commitIndex, state1.commitIndex);
+        assertEquals(state.votedFor, state1.votedFor);
+        rounds = rounds - 1;
+    end
+    
+    local config1 = manager:loadClusterConfiguration();
+    assertConfigEquals(config, config1);
+    config = randomConfiguration();
+    manager:saveClusterConfiguration(config);
+    config1 = manager:loadClusterConfiguration();
+    assertConfigEquals(config, config1);
+    
+    -- clean up
+    manager:close();
+    removeTestFiles(container);
+end
+
+
+function randomConfiguration()
+    local config = ClusterConfiguration:new();
+    config.lastLogIndex = math.random(MAX_LONG);
+    config.logIndex = math.random(MAX_LONG);
+    local servers = math.random(10) + 1;
+    for i = 1, servers do
+        local server = ClusterServer:new();
+        server.id = math.random(MAX_INT);
+        server.endpoint = string.format("Server %d", (i + 1));
+        config.servers[#config.servers + 1] = server;
+    end
+    
+    return config;
+end
+
+
+function assertConfigEquals(config, config1)
+    assertEquals(config.lastLogIndex, config1.lastLogIndex);
+    assertEquals(config.logIndex, config1.logIndex);
+    assertEquals(#config.servers, #config1.servers);
+    for i = 1, #config.servers do
+        local s1 = config.servers[i];
+        local s2 = config.servers[i];
+        assertEquals(s1.id, s2.id);
+        assertEquals(s1.endpoint, s2.endpoint);
+    end
+end
+
+
+function removeTestFiles(container)
+    commonlib.Files.DeleteFolder(container);
+end

--- a/npl_mod/Raft/test/TestSqliteBasedServerStateManager.lua
+++ b/npl_mod/Raft/test/TestSqliteBasedServerStateManager.lua
@@ -21,8 +21,8 @@ NPL.load("(gl)npl_mod/Raft/SqliteBasedServerStateManager.lua");
 local SqliteBasedServerStateManager = commonlib.gettable("Raft.SqliteBasedServerStateManager");
 
 
-local MAX_LONG = 2 ^ 63 - 1;
-local MAX_INT = 2 ^ 31 - 1;
+local MAX_LONG = 2 ^ 13 - 1;
+local MAX_INT = 2 ^ 13 - 1;
 
 local removeTestFiles, randomConfiguration, assertConfigEquals;
 

--- a/npl_mod/Raft/test/TestWALSequentialLogStore.lua
+++ b/npl_mod/Raft/test/TestWALSequentialLogStore.lua
@@ -1,0 +1,302 @@
+--[[
+Title: 
+Author: liuluheng
+Date: 2017.04.03
+Desc: 
+TEST WALSequentialLogStore
+------------------------------------------------------------
+NPL.load("(gl)script/ide/UnitTest/luaunit.lua");
+NPL.load("(gl)npl_mod/Raft/test/TestWALSequentialLogStore.lua");
+LuaUnit:run('TestWALSequentialLogStore') 
+------------------------------------------------------------
+]]--
+
+NPL.load("(gl)script/ide/Files.lua");
+NPL.load("(gl)npl_mod/Raft/LogEntry.lua");
+local LogEntry = commonlib.gettable("Raft.LogEntry");
+NPL.load("(gl)npl_mod/Raft/WALSequentialLogStore.lua");
+local WALSequentialLogStore = commonlib.gettable("Raft.WALSequentialLogStore");
+NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
+local util = commonlib.gettable("System.Compiler.lib.util")
+
+NPL.load("(gl)npl_mod/Raft/test/TestUtil.lua");
+NPL.load("(gl)script/ide/UnitTest/luaunit.lua");
+
+
+local MAX_LONG = 2^13 - 1;
+local MAX_INT = 2^31 - 1;
+
+local removeTestFiles, randomLogEntry, logEntriesEquals;
+
+local assertTrue = assert
+
+TestWALSequentialLogStore = {}
+
+function TestWALSequentialLogStore:testBuffer()
+    local container = "temp/snapshot/";
+    -- commonlib.Files.TouchFolder(container); -- this not works
+    removeTestFiles(container);
+    ParaIO.CreateDirectory(container);
+    local store = WALSequentialLogStore:new(container);
+    local logsCount = math.random(1000) + 1500;
+    local entries = {};
+    for i = 1, logsCount do
+        local entry = randomLogEntry();
+        store:append(entry);
+        entries[#entries + 1] = entry;
+    end
+
+    local start = math.random(logsCount - 1000);
+    local endi = logsCount - 500;
+    local results = store:getLogEntries(start, endi);
+    assertEquals(#results, endi - start)
+    for i = start, endi - 1 do
+        logEntriesEquals(entries[i], results[i - start + 1]);
+    end
+
+    store:close();
+
+    removeTestFiles(container);
+end
+
+function TestWALSequentialLogStore:testPackAndUnpack()
+    local container = "temp/snapshot/";
+    removeTestFiles(container);
+    ParaIO.CreateDirectory(container);
+    local container1 = "temp/snapshot1/";
+    removeTestFiles(container1);
+    ParaIO.CreateDirectory(container1);
+    local store = WALSequentialLogStore:new(container);
+    local store1 = WALSequentialLogStore:new(container1);
+
+    -- write some logs
+    local logsCount = math.random(1000) + 1000;
+    for i = 1,logsCount  do
+        local entry = randomLogEntry();
+        store:append(entry);
+        store1:append(entry);
+    end
+
+    local logsCopied = 0;
+    while(logsCopied < logsCount) do
+        local pack = store:packLog(logsCopied + 1, 100);
+        store1:applyLogPack(logsCopied + 1, pack);
+        logsCopied = math.min(logsCopied + 100,  logsCount);
+    end
+
+    assertEquals(store:getFirstAvailableIndex(), store1:getFirstAvailableIndex());
+    for i = 1, logsCount do
+        local entry1 = store:getLogEntryAt(i);
+        local entry2 = store1:getLogEntryAt(i);
+        assertTrue( logEntriesEquals(entry1, entry2),
+            format("the " .. i .. "th value are not equal(total: " .. logsCount .. ")\n\tentry1:%s,\n\tentry2:%s",
+                    util.table_tostring(entry1), util.table_tostring(entry2)));
+    end
+
+    store:close();
+    store1:close();
+    removeTestFiles(container);
+    removeTestFiles(container1);
+end
+
+
+function TestWALSequentialLogStore:testStore()
+    local container = "temp/snapshot/";
+    removeTestFiles(container);
+    ParaIO.CreateDirectory(container);
+    local store = WALSequentialLogStore:new(container);
+    assertTrue(store:getLastLogEntry().term == 0);
+    assertTrue(store:getLastLogEntry().value == nil);
+    assertEquals(1, store:getFirstAvailableIndex());
+    assertTrue(store:getLogEntryAt(1) == nil);
+
+    -- write some logs
+    local entries = {};
+    for i = 1, math.random(100) + 10 do
+        local entry = randomLogEntry();
+        store:append(entry);
+        entries[#entries + 1] = entry;
+    end
+
+
+    assertEquals(#entries, store:getFirstAvailableIndex() - 1);
+    assertTrue(logEntriesEquals(entries[#entries], store:getLastLogEntry()));
+
+    -- random item
+    local randomIndex = math.random(#entries);
+    assertTrue(logEntriesEquals(entries[randomIndex], store:getLogEntryAt(randomIndex))); -- log store's index starts from 1
+
+    -- random range
+    randomIndex = math.random(#entries);
+    local randomSize = math.random(#entries - randomIndex);
+    local logEntries = store:getLogEntries(randomIndex, randomIndex + randomSize);
+
+    for i= randomIndex, randomIndex + randomSize - 1 do
+        assertTrue(logEntriesEquals(entries[i], logEntries[i - randomIndex + 1]));
+    end
+
+
+    -- WAL new not read logs
+    -- store:close();
+    -- store = WALSequentialLogStore:new(container);
+
+    assertEquals(#entries, store:getFirstAvailableIndex() - 1);
+    assertTrue(logEntriesEquals(entries[#entries], store:getLastLogEntry()));
+
+    -- random item
+    randomIndex = math.random(#entries);
+    assertTrue(logEntriesEquals(entries[randomIndex], store:getLogEntryAt(randomIndex))); -- log store's index starts from 1
+
+    -- random range
+    randomIndex = math.random(#entries);
+    randomSize = math.random(#entries - randomIndex);
+    logEntries = store:getLogEntries(randomIndex, randomIndex + randomSize);
+
+    for i= randomIndex, randomIndex + randomSize - 1 do
+        assertTrue(logEntriesEquals(entries[i], logEntries[i - randomIndex + 1]));
+    end
+
+    -- test with edge
+    randomSize = math.random(#entries);
+    logEntries = store:getLogEntries(store:getFirstAvailableIndex() - randomSize, store:getFirstAvailableIndex());
+
+    local j = 1
+    for i= #entries - randomSize + 1, #entries do
+        assertTrue(logEntriesEquals(entries[i], logEntries[j]));
+        j = j + 1;
+    end
+
+    -- test write at
+    local logEntry = randomLogEntry();
+    randomIndex = math.random(store:getFirstAvailableIndex() - 1);
+    store:writeAt(store:getStartIndex() + randomIndex, logEntry);
+    assertEquals(randomIndex + store:getStartIndex(), store:getFirstAvailableIndex());
+    assertTrue(logEntriesEquals(logEntry, store:getLastLogEntry()));
+
+    store:close();
+    removeTestFiles(container);
+end
+
+function TestWALSequentialLogStore:testCompactRandom()
+    local container = "temp/snapshot/";
+    -- commonlib.Files.TouchFolder(container); -- this not works
+    removeTestFiles(container);
+    ParaIO.CreateDirectory(container);
+    local store = WALSequentialLogStore:new(container);
+    local logsCount = 300;
+    local entries = {};
+    for i = 1, logsCount do
+        local entry = randomLogEntry();
+        store:append(entry);
+        entries[#entries + 1] = entry;
+    end
+
+    local lastLogIndex = #entries;
+    local indexToCompact = math.random(lastLogIndex - 10) + 1;
+    store:compact(indexToCompact);
+
+    assertEquals(indexToCompact + 1, store:getStartIndex());
+    assertEquals(#entries, store:getFirstAvailableIndex() - 1);
+
+    for i = 1, store:getFirstAvailableIndex() - indexToCompact - 1 do
+        local entry = store:getLogEntryAt(store:getStartIndex() + i - 1);
+        assertTrue(logEntriesEquals(entries[i + indexToCompact], entry));
+    end
+
+    local randomIndex = math.random(store:getFirstAvailableIndex() - indexToCompact - 1);
+    local logEntry = randomLogEntry();
+    store:writeAt(store:getStartIndex() + randomIndex, logEntry);
+    entries[randomIndex + indexToCompact + 1] = logEntry;
+
+    for i=randomIndex + indexToCompact + 2,#entries do
+        entries[i] = nil;
+    end
+
+    for i = 1, store:getFirstAvailableIndex() - indexToCompact - 1 do
+        local entry = store:getLogEntryAt(store:getStartIndex() + i - 1);
+        assertTrue(logEntriesEquals(entries[i + indexToCompact], entry));
+    end
+
+    for i = 1, math.random(100) + 10 do
+        local entry = randomLogEntry();
+        entries[#entries + 1] = entry;
+        store:append(entry);
+    end
+
+    for i = 1, store:getFirstAvailableIndex() - indexToCompact - 1 do
+        local entry = store:getLogEntryAt(store:getStartIndex() + i - 1);
+        assertTrue(logEntriesEquals(entries[i + indexToCompact], entry));
+    end
+
+
+    store:close();
+    removeTestFiles(container);
+
+end
+
+function TestWALSequentialLogStore:testCompactAll()
+    local container = "temp/snapshot/";
+    removeTestFiles(container);
+    ParaIO.CreateDirectory(container);
+    local store = WALSequentialLogStore:new(container);
+
+    -- write some logs
+    local entries = {};
+    for i = 1, math.random(1000) + 10 do
+        local entry = randomLogEntry();
+        entries[#entries + 1] = entry;
+        store:append(entry);
+    end
+
+    assertEquals(1, store:getStartIndex());
+    assertEquals(#entries, store:getFirstAvailableIndex() - 1);
+    assertTrue(logEntriesEquals(entries[#entries], store:getLastLogEntry()));
+    local lastLogIndex = #entries;
+    store:compact(lastLogIndex);
+
+    assertEquals(#entries + 1, store:getStartIndex());
+    assertEquals(#entries, store:getFirstAvailableIndex() - 1);
+
+    for i = 1, math.random(100) + 10 do
+        local entry = randomLogEntry();
+        entries[#entries + 1] = entry;
+        store:append(entry);
+    end
+
+    assertEquals(lastLogIndex + 1, store:getStartIndex());
+    assertEquals(#entries, store:getFirstAvailableIndex() - 1);
+    assertTrue(logEntriesEquals(entries[#entries], store:getLastLogEntry()));
+
+    local index = store:getStartIndex() + math.random(store:getFirstAvailableIndex() - store:getStartIndex());
+    assertTrue(logEntriesEquals(entries[index], store:getLogEntryAt(index)));
+
+    store:close();
+    removeTestFiles(container);
+end
+
+
+function removeTestFiles(container)
+    commonlib.Files.DeleteFolder(container);
+end
+
+function randomLogEntry()
+    local term = math.random(MAX_LONG);
+    local value = string.random(math.random( 4096 ), "%l%d")
+    local type = math.random(5) - 1;
+    return LogEntry:new(term, value, type);
+end
+
+function logEntriesEquals(entry1, entry2)
+    local equals = entry1.term == entry2.term and entry1.valueType == entry2.valueType;
+
+    equals = equals and ((entry1.value ~= nil and entry2.value ~= nil and #entry1.value == #entry2.value) or (entry1.value == nil and entry2.value == nil));
+    if(entry1.value ~= nil) then
+        local i = 1;
+        while(equals and i < #entry1.value) do
+            equals = string.byte(entry1.value, i) == string.byte(entry2.value, i);
+            i = i + 1;
+        end
+    end
+
+    return equals;
+end

--- a/npl_mod/Raft/test/TestWALSequentialLogStore.lua
+++ b/npl_mod/Raft/test/TestWALSequentialLogStore.lua
@@ -1,16 +1,16 @@
 --[[
-Title: 
+Title:
 Author: liuluheng
 Date: 2017.04.03
-Desc: 
+Desc:
 TEST WALSequentialLogStore
 ------------------------------------------------------------
 NPL.load("(gl)script/ide/UnitTest/luaunit.lua");
 NPL.load("(gl)npl_mod/Raft/test/TestWALSequentialLogStore.lua");
-LuaUnit:run('TestWALSequentialLogStore') 
+LuaUnit:run('TestWALSequentialLogStore')
 ------------------------------------------------------------
-]]--
-
+]]
+--
 NPL.load("(gl)script/ide/Files.lua");
 NPL.load("(gl)npl_mod/Raft/LogEntry.lua");
 local LogEntry = commonlib.gettable("Raft.LogEntry");
@@ -23,8 +23,8 @@ NPL.load("(gl)npl_mod/Raft/test/TestUtil.lua");
 NPL.load("(gl)script/ide/UnitTest/luaunit.lua");
 
 
-local MAX_LONG = 2^13 - 1;
-local MAX_INT = 2^31 - 1;
+local MAX_LONG = 2 ^ 13 - 1;
+local MAX_INT = 2 ^ 31 - 1;
 
 local removeTestFiles, randomLogEntry, logEntriesEquals;
 
@@ -45,7 +45,7 @@ function TestWALSequentialLogStore:testBuffer()
         store:append(entry);
         entries[#entries + 1] = entry;
     end
-
+    
     local start = math.random(logsCount - 1000);
     local endi = logsCount - 500;
     local results = store:getLogEntries(start, endi);
@@ -53,9 +53,9 @@ function TestWALSequentialLogStore:testBuffer()
     for i = start, endi - 1 do
         logEntriesEquals(entries[i], results[i - start + 1]);
     end
-
+    
     store:close();
-
+    
     removeTestFiles(container);
 end
 
@@ -68,31 +68,67 @@ function TestWALSequentialLogStore:testPackAndUnpack()
     ParaIO.CreateDirectory(container1);
     local store = WALSequentialLogStore:new(container);
     local store1 = WALSequentialLogStore:new(container1);
-
+    
     -- write some logs
     local logsCount = math.random(1000) + 1000;
-    for i = 1,logsCount  do
+    for i = 1, logsCount do
         local entry = randomLogEntry();
         store:append(entry);
         store1:append(entry);
     end
-
+    
     local logsCopied = 0;
-    while(logsCopied < logsCount) do
+    while (logsCopied < logsCount) do
         local pack = store:packLog(logsCopied + 1, 100);
         store1:applyLogPack(logsCopied + 1, pack);
-        logsCopied = math.min(logsCopied + 100,  logsCount);
+        logsCopied = math.min(logsCopied + 100, logsCount);
     end
-
+    
     assertEquals(store:getFirstAvailableIndex(), store1:getFirstAvailableIndex());
     for i = 1, logsCount do
         local entry1 = store:getLogEntryAt(i);
         local entry2 = store1:getLogEntryAt(i);
-        assertTrue( logEntriesEquals(entry1, entry2),
+        assertTrue(logEntriesEquals(entry1, entry2),
             format("the " .. i .. "th value are not equal(total: " .. logsCount .. ")\n\tentry1:%s,\n\tentry2:%s",
-                    util.table_tostring(entry1), util.table_tostring(entry2)));
+                util.table_tostring(entry1), util.table_tostring(entry2)));
     end
+    
 
+    -- test append after applyLogPack
+    -- write some logs
+    local entries = {};
+    for i = 1, math.random(100) + 10 do
+        local entry = randomLogEntry();
+        store1:append(entry);
+        entries[#entries + 1] = entry;
+    end
+    
+    assertEquals(#entries + logsCount, store1:getFirstAvailableIndex() - 1);
+    -- print(util.table_tostring(entries[#entries]), util.table_tostring(store1:getLastLogEntry()))
+    assertTrue(logEntriesEquals(entries[#entries], store1:getLastLogEntry()));
+    assertTrue(logEntriesEquals(entries[#entries], store1:getLogEntryAt(#entries + logsCount)));
+    
+    -- random item
+    local randomIndex = math.random(#entries);
+    assertTrue(logEntriesEquals(entries[randomIndex], store1:getLogEntryAt(randomIndex + logsCount))); -- log store's index starts from 1
+    
+    -- random range
+    randomIndex = math.random(#entries);
+    local randomSize = math.random(#entries - randomIndex);
+    local logEntries = store1:getLogEntries(randomIndex, randomIndex + logsCount + randomSize);
+    
+    for i = randomIndex, randomIndex + randomSize - 1 do
+        assertTrue(logEntriesEquals(entries[i], logEntries[i - randomIndex + 1 + logsCount]));
+    end
+    
+    
+    -- test write at
+    local logEntry = randomLogEntry();
+    randomIndex = math.random(store1:getFirstAvailableIndex() - 1);
+    store1:writeAt(store1:getStartIndex() + randomIndex, logEntry);
+    assertEquals(randomIndex + store1:getStartIndex(), store1:getFirstAvailableIndex());
+    assertTrue(logEntriesEquals(logEntry, store1:getLastLogEntry()));
+    
     store:close();
     store1:close();
     removeTestFiles(container);
@@ -109,7 +145,7 @@ function TestWALSequentialLogStore:testStore()
     assertTrue(store:getLastLogEntry().value == nil);
     assertEquals(1, store:getFirstAvailableIndex());
     assertTrue(store:getLogEntryAt(1) == nil);
-
+    
     -- write some logs
     local entries = {};
     for i = 1, math.random(100) + 10 do
@@ -117,62 +153,61 @@ function TestWALSequentialLogStore:testStore()
         store:append(entry);
         entries[#entries + 1] = entry;
     end
-
-
+    
+    
     assertEquals(#entries, store:getFirstAvailableIndex() - 1);
     assertTrue(logEntriesEquals(entries[#entries], store:getLastLogEntry()));
-
+    
     -- random item
     local randomIndex = math.random(#entries);
     assertTrue(logEntriesEquals(entries[randomIndex], store:getLogEntryAt(randomIndex))); -- log store's index starts from 1
-
+    
     -- random range
     randomIndex = math.random(#entries);
     local randomSize = math.random(#entries - randomIndex);
     local logEntries = store:getLogEntries(randomIndex, randomIndex + randomSize);
-
-    for i= randomIndex, randomIndex + randomSize - 1 do
+    
+    for i = randomIndex, randomIndex + randomSize - 1 do
         assertTrue(logEntriesEquals(entries[i], logEntries[i - randomIndex + 1]));
     end
-
-
+    
+    
     -- WAL new not read logs
     -- store:close();
     -- store = WALSequentialLogStore:new(container);
-
     assertEquals(#entries, store:getFirstAvailableIndex() - 1);
     assertTrue(logEntriesEquals(entries[#entries], store:getLastLogEntry()));
-
+    
     -- random item
     randomIndex = math.random(#entries);
     assertTrue(logEntriesEquals(entries[randomIndex], store:getLogEntryAt(randomIndex))); -- log store's index starts from 1
-
+    
     -- random range
     randomIndex = math.random(#entries);
     randomSize = math.random(#entries - randomIndex);
     logEntries = store:getLogEntries(randomIndex, randomIndex + randomSize);
-
-    for i= randomIndex, randomIndex + randomSize - 1 do
+    
+    for i = randomIndex, randomIndex + randomSize - 1 do
         assertTrue(logEntriesEquals(entries[i], logEntries[i - randomIndex + 1]));
     end
-
+    
     -- test with edge
     randomSize = math.random(#entries);
     logEntries = store:getLogEntries(store:getFirstAvailableIndex() - randomSize, store:getFirstAvailableIndex());
-
+    
     local j = 1
-    for i= #entries - randomSize + 1, #entries do
+    for i = #entries - randomSize + 1, #entries do
         assertTrue(logEntriesEquals(entries[i], logEntries[j]));
         j = j + 1;
     end
-
+    
     -- test write at
     local logEntry = randomLogEntry();
     randomIndex = math.random(store:getFirstAvailableIndex() - 1);
     store:writeAt(store:getStartIndex() + randomIndex, logEntry);
     assertEquals(randomIndex + store:getStartIndex(), store:getFirstAvailableIndex());
     assertTrue(logEntriesEquals(logEntry, store:getLastLogEntry()));
-
+    
     store:close();
     removeTestFiles(container);
 end
@@ -190,45 +225,45 @@ function TestWALSequentialLogStore:testCompactRandom()
         store:append(entry);
         entries[#entries + 1] = entry;
     end
-
+    
     local lastLogIndex = #entries;
     local indexToCompact = math.random(lastLogIndex - 10) + 1;
     store:compact(indexToCompact);
-
+    
     assertEquals(indexToCompact + 1, store:getStartIndex());
     assertEquals(#entries, store:getFirstAvailableIndex() - 1);
-
+    
     for i = 1, store:getFirstAvailableIndex() - indexToCompact - 1 do
         local entry = store:getLogEntryAt(store:getStartIndex() + i - 1);
         assertTrue(logEntriesEquals(entries[i + indexToCompact], entry));
     end
-
+    
     local randomIndex = math.random(store:getFirstAvailableIndex() - indexToCompact - 1);
     local logEntry = randomLogEntry();
     store:writeAt(store:getStartIndex() + randomIndex, logEntry);
     entries[randomIndex + indexToCompact + 1] = logEntry;
-
-    for i=randomIndex + indexToCompact + 2,#entries do
+    
+    for i = randomIndex + indexToCompact + 2, #entries do
         entries[i] = nil;
     end
-
+    
     for i = 1, store:getFirstAvailableIndex() - indexToCompact - 1 do
         local entry = store:getLogEntryAt(store:getStartIndex() + i - 1);
         assertTrue(logEntriesEquals(entries[i + indexToCompact], entry));
     end
-
+    
     for i = 1, math.random(100) + 10 do
         local entry = randomLogEntry();
         entries[#entries + 1] = entry;
         store:append(entry);
     end
-
+    
     for i = 1, store:getFirstAvailableIndex() - indexToCompact - 1 do
         local entry = store:getLogEntryAt(store:getStartIndex() + i - 1);
         assertTrue(logEntriesEquals(entries[i + indexToCompact], entry));
     end
-
-
+    
+    
     store:close();
     removeTestFiles(container);
 
@@ -239,7 +274,7 @@ function TestWALSequentialLogStore:testCompactAll()
     removeTestFiles(container);
     ParaIO.CreateDirectory(container);
     local store = WALSequentialLogStore:new(container);
-
+    
     -- write some logs
     local entries = {};
     for i = 1, math.random(1000) + 10 do
@@ -247,29 +282,29 @@ function TestWALSequentialLogStore:testCompactAll()
         entries[#entries + 1] = entry;
         store:append(entry);
     end
-
+    
     assertEquals(1, store:getStartIndex());
     assertEquals(#entries, store:getFirstAvailableIndex() - 1);
     assertTrue(logEntriesEquals(entries[#entries], store:getLastLogEntry()));
     local lastLogIndex = #entries;
     store:compact(lastLogIndex);
-
+    
     assertEquals(#entries + 1, store:getStartIndex());
     assertEquals(#entries, store:getFirstAvailableIndex() - 1);
-
+    
     for i = 1, math.random(100) + 10 do
         local entry = randomLogEntry();
         entries[#entries + 1] = entry;
         store:append(entry);
     end
-
+    
     assertEquals(lastLogIndex + 1, store:getStartIndex());
     assertEquals(#entries, store:getFirstAvailableIndex() - 1);
     assertTrue(logEntriesEquals(entries[#entries], store:getLastLogEntry()));
-
+    
     local index = store:getStartIndex() + math.random(store:getFirstAvailableIndex() - store:getStartIndex());
     assertTrue(logEntriesEquals(entries[index], store:getLogEntryAt(index)));
-
+    
     store:close();
     removeTestFiles(container);
 end
@@ -281,22 +316,22 @@ end
 
 function randomLogEntry()
     local term = math.random(MAX_LONG);
-    local value = string.random(math.random( 4096 ), "%l%d")
+    local value = string.random(math.random(4096), "%l%d")
     local type = math.random(5) - 1;
     return LogEntry:new(term, value, type);
 end
 
 function logEntriesEquals(entry1, entry2)
     local equals = entry1.term == entry2.term and entry1.valueType == entry2.valueType;
-
+    
     equals = equals and ((entry1.value ~= nil and entry2.value ~= nil and #entry1.value == #entry2.value) or (entry1.value == nil and entry2.value == nil));
-    if(entry1.value ~= nil) then
+    if (entry1.value ~= nil) then
         local i = 1;
-        while(equals and i < #entry1.value) do
+        while (equals and i < #entry1.value) do
             equals = string.byte(entry1.value, i) == string.byte(entry2.value, i);
             i = i + 1;
         end
     end
-
+    
     return equals;
 end

--- a/npl_mod/TableDB/RaftSqliteStore.lua
+++ b/npl_mod/TableDB/RaftSqliteStore.lua
@@ -1,8 +1,9 @@
 --[[
-Title: base class for store
+Title: RaftSqliteStore
 Author(s): liuluheng, 
 Date: 2017/7/31
-Desc: 
+Desc:
+
 use the lib:
 ------------------------------------------------------------
 NPL.load("(gl)npl_mod/TableDB/RaftSqliteStore.lua");
@@ -10,73 +11,438 @@ local RaftSqliteStore = commonlib.gettable("TableDB.RaftSqliteStore");
 ------------------------------------------------------------
 ]]
 
+NPL.load("(gl)script/ide/System/Database/StorageProvider.lua");
+local StorageProvider = commonlib.gettable("System.Database.StorageProvider");
+NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
+local util = commonlib.gettable("System.Compiler.lib.util")
+NPL.load("(gl)npl_mod/TableDB/RaftLogEntryValue.lua");
+local RaftLogEntryValue = commonlib.gettable("TableDB.RaftLogEntryValue");
+NPL.load("(gl)npl_mod/Raft/ServerStateManager.lua");
+local ServerStateManager = commonlib.gettable("Raft.ServerStateManager");
+NPL.load("(gl)npl_mod/TableDB/RaftTableDBStateMachine.lua");
+local RaftTableDBStateMachine = commonlib.gettable("TableDB.RaftTableDBStateMachine");
+NPL.load("(gl)npl_mod/Raft/RaftClient.lua");
+local RaftClient = commonlib.gettable("Raft.RaftClient");
+local LoggerFactory = NPL.load("(gl)npl_mod/Raft/LoggerFactory.lua");
+local logger = LoggerFactory.getLogger("RaftSqliteStore")
 
-NPL.load("(gl)script/ide/commonlib.lua");
-NPL.load("(gl)script/sqlite/sqlite3.lua");
+local RaftSqliteStore = commonlib.inherit(commonlib.gettable("System.Database.Store"), commonlib.gettable("TableDB.RaftSqliteStore"));
 
-NPL.load("(gl)script/ide/System/Database/SqliteStore.lua");
-local SqliteStore = commonlib.gettable("System.Database.SqliteStore");
-local RaftSqliteStore = commonlib.inherit(SqliteStore, commonlib.gettable("TableDB.RaftSqliteStore"));
+local callbackQueue = {};
+local raftClient;
 
-local follower_dbs = {}
+RaftSqliteStore.name = "raft";
+RaftSqliteStore.thread_name = format("(%s)", __rts__:GetName());
+
+function RaftSqliteStore:createRaftClient(baseDir, host, port, id, threadName, rootFolder)
+  local baseDir = baseDir or "./"
+  local stateManager = ServerStateManager:new(baseDir);
+  local config = stateManager:loadClusterConfiguration();
+
+  local localAddress = {
+    host = host or "localhost",
+    port = port or "9004",
+    id = id or "server4:",
+  }
+
+  if #localAddress.id < 4 then
+    localAddress.id = format("server%s:", localAddress.id)
+  end
+
+  rtdb = RaftTableDBStateMachine:new(baseDir, localAddress.host, localAddress.port, threadName)
+  
+  NPL.StartNetServer(localAddress.host, localAddress.port);
+
+  rtdb:start2(self)
+  raftClient = RaftClient:new(localAddress, RTDBRequestRPC, config, LoggerFactory)
+
+  self:connect(self, {rootFolder = rootFolder});
+
+
+end
+
+function RaftSqliteStore:setRaftClient(c)
+  raftClient = c
+end
+
+function RaftSqliteStore:getRaftClient()
+  return raftClient;
+end
 
 function RaftSqliteStore:ctor()
+  self.stats = {
+    select = 0,
+    update = 0,
+    insert = 0,
+    delete = 0,
+  };
+
+  -- StorageProvider:RegisterStorageClass(self.name, self)
+
 end
 
 function RaftSqliteStore:init(collection, init_args)
-  RaftSqliteStore._super.init(self, collection);
-  local dbName = self.kFileName
   self.collection = collection;
-
-  self._db:set_wal_page_hook(function (page_data, pgno, nTruncate, isCommit)
-    local db2 = follower_dbs[collection:GetName()];
-    if not db2 then
-      db2 = sqlite3.open(dbName .. "2")
-      db2:exec("PRAGMA journal_mode=WAL;");
-      db2:exec("PRAGMA synchronous=NORMAL;");
-      follower_dbs[collection:GetName()] = db2;
-    end
-    -- followers simply append wal, no need to worry about the meta data
-    print(format("wal_page_hook: pgSize %d, pgno %d, nTruncate %d, isCommit %d", #page_data, pgno, nTruncate, isCommit))
-    db2:wal_inject_page(page_data, pgno, nTruncate, isCommit)
-    return 1
-  end)
-
-  self._db:set_wal_checkpoint_hook(function ()
-    print("wal_checkpoint_hook")
-    follower_dbs[self.collection:GetName()]:wal_checkpoint("main")
-    return 1
-  end)
-
-  -- create meta data in sqliteStore
-	self:Begin();
-		-- drop all tables. 
-		self:DropAllMetaTables();
-	
-		-- create all tables
-		self:CreateTables();
-
-		-- insert version infos
-		local insert_stmt = assert(self._db:prepare("INSERT INTO SystemInfo (Name, Value) VALUES(?, ?)"));
-		insert_stmt:bind("version", SqliteStore.kCurrentVersion);
-		insert_stmt:exec();
-		insert_stmt:bind("author", "NPLRuntime");
-		insert_stmt:exec();
-		insert_stmt:bind("name", self:GetCollection():GetName());
-		insert_stmt:exec();
-		insert_stmt:close();
-
-	self:End();
-	self:FlushAll();
-	LOG.std(nil, "TableDB", "RaftSqliteStore", "%s is recreated for raft", self.kFileName);
-	self:ValidateDB();
-
+  print(util.table_tostring(init_args))
+  if not raftClient then
+    self:createRaftClient(unpack(init_args));
+  end
   return self;
 end
 
-function RaftSqliteStore:Close()
-    RaftSqliteStore._super.Close(self)
-    -- send close
-    follower_dbs[self.collection:GetName()]:close()
-    follower_dbs[self.collection:GetName()] = nil;
+
+
+-- how many seconds to wait on busy database, before we send "queue_full" error. This parameter only takes effect when self.WaitOnBusyDB is true.
+RaftSqliteStore.MaxWaitSeconds = 5;
+-- default time out for a given request. default to 5 seconds
+RaftSqliteStore.DefaultTimeout = 5000;
+-- internal timer period
+RaftSqliteStore.monitorPeriod = 5000;
+-- true to log everything.
+RaftSqliteStore.debug_log = false;
+
+function RaftSqliteStore:OneTimeInit()
+  if(self.inited) then
+    return;
+  end
+  self.inited = true;
+  NPL.load("(gl)script/ide/timer.lua");
+  self.mytimer = commonlib.Timer:new({callbackFunc = function(timer)
+    self:CheckTimedOutRequests();
+  end})
+  self.mytimer:Change(self.monitorPeriod, self.monitorPeriod);
+end
+
+-- remove any timed out request.
+function RaftSqliteStore:CheckTimedOutRequests()
+  local curTime = ParaGlobal.timeGetTime();
+  local timeout_pool;
+  for i, cb in pairs(callbackQueue) do
+    if((curTime - cb.startTime) > (cb.timeout or self.DefaultTimeout) ) then
+      timeout_pool = timeout_pool or {};
+      timeout_pool[i] = cb;
+    end
+  end
+  if(timeout_pool) then
+    for i, cb in pairs(timeout_pool) do
+      callbackQueue[i] = nil;
+      if(cb.callbackFunc) then
+        cb.callbackFunc("timeout", nil);
+      end
+    end
+  end
+end
+
+local next_id = 0;
+function getNextId()
+  next_id = next_id + 1;
+  return next_id;
+end
+-- get next callback pool index. may return nil if max queue size is reached. 
+-- @return index or nil
+function RaftSqliteStore:PushCallback(callbackFunc, timeout)
+  -- if(not callbackFunc) then
+  --   return -1;
+  -- end
+  local index = getNextId();
+  callbackQueue[index] = {callbackFunc = callbackFunc, startTime = ParaGlobal.timeGetTime(), timeout=timeout};
+  return index;
+end
+
+function RaftSqliteStore:PopCallback(index)
+  if(index) then
+    local cb = callbackQueue[index];
+    if(cb) then
+      callbackQueue[index] = nil;
+      return cb;
+    end
+  end
+end
+
+-- return err, data.
+function RaftSqliteStore:WaitForSyncModeReply(timeout, cb_index)
+  timeout = timeout or self.DefaultTimeout;
+  local thread = __rts__;
+  local reply_msg;
+  local startTime = ParaGlobal.timeGetTime();
+  while (not reply_msg) do
+    local nSize = thread:GetCurrentQueueSize();
+    for i=0, nSize-1 do
+      local msg = thread:PeekMessage(i, {filename=true});
+      if(msg.filename == "Rpc/RTDBRequestRPC.lua") then
+        local msg = thread:PopMessageAt(i, {filename=true, msg=true});
+        local out_msg = msg.msg;
+        logger.trace("recv msg:%s", util.table_tostring(out_msg));
+        -- we use this only in connect and we should ensure connect's cb_index should be -1
+        if not RaftSqliteStore.EnableSyncMode then
+          raftClient.HandleResponse(nil, out_msg.msg);
+        else
+          RaftSqliteStore:handleResponse(out_msg.msg);
+        end
+        if(cb_index and out_msg.msg and out_msg.msg.cb_index == cb_index) or
+           (cb_index == nil and out_msg.msg and out_msg.msg.destination and out_msg.msg.destination ~= -1) then
+          logger.debug("got the correct msg");
+          reply_msg = out_msg.msg;
+          break;
+        end
+      end
+    end
+    if( (ParaGlobal.timeGetTime() - startTime) > timeout) then
+      LOG.std(nil, "warn", "RaftSqliteStore", "timed out");
+      return "timeout", nil;
+    end
+    if(reply_msg == nil) then
+      if(ParaEngine.GetAttributeObject():GetField("HasClosingRequest", false) == true) then
+        return "app_exit", nil;
+      end
+      if(thread:GetCurrentQueueSize() == nSize) then
+        thread:WaitForMessage(nSize);
+      end
+    end
+  end
+  if(reply_msg) then
+    return reply_msg.err, reply_msg.data;
+  end
+end
+
+
+function RaftSqliteStore:handleResponse(msg)
+  local cb = self:PopCallback(msg.cb_index);
+  if(cb and cb.callbackFunc) then
+    cb.callbackFunc(msg.err, msg.data);
+  end
+end
+
+-- called when a single command is finished. 
+function RaftSqliteStore:CommandTick(commandname)
+  if(commandname) then
+    self:AddStat(commandname, 1);
+  end
+end
+
+function RaftSqliteStore:GetCollection()
+  return self.collection;
+end
+
+function RaftSqliteStore:GetStats()
+  return self.stats;
+end
+
+-- add statistics for a given name
+-- @param name: such as "select", "update", "insert", "delete"
+-- @param count: if nil it is 1.
+function RaftSqliteStore:AddStat(name, count)
+  name = name or "unknown";
+  local stats = self:GetStats();
+  stats[name] = (stats[name] or 0) + (count or 1);
+end
+
+-- get current count for a given stats name
+-- @param name: such as "select", "update", "insert", "delete"
+function RaftSqliteStore:GetStat(name)
+  name = name or "unknown";
+  local stats = self:GetStats();
+  return (stats[name] or 0);
+end
+
+function RaftSqliteStore:InvokeCallback(callbackFunc, err, data)
+  if(callbackFunc) then
+    callbackFunc(err, data);
+  else
+    return data;
+  end
+end
+
+
+function RaftSqliteStore:connect(db, data, callbackFunc)
+  local query_type = "connect"
+  local collection = {
+    ToData = function (...)	end,
+  }
+
+  local query = {
+    rootFolder = data.rootFolder,
+  }
+
+  local raftLogEntryValue = RaftLogEntryValue:new(query_type, collection, query, -1,
+                                                  raftClient.localAddress.id,
+                                                  RaftSqliteStore.EnableSyncMode,
+                                                  RaftSqliteStore.thread_name);
+  local bytes = raftLogEntryValue:toBytes();
+
+  -- if not raftClient then
+  --   self:createRaftClient()
+  -- end
+
+  raftClient:appendEntries(bytes, function (response, err)
+      local result = (err == nil and response.accepted and "accepted") or "denied"
+      logger.info("the %s request has been %s", query_type, result)
+      if callbackFunc then
+        callbackFunc(err, response.data);
+      end
+    end)
+
+  self:WaitForSyncModeReply(10000);
+end
+
+
+function RaftSqliteStore:Send(query_type, query, callbackFunc)
+  self:OneTimeInit();
+  local index = self:PushCallback(callbackFunc);
+  if(index) then
+    local raftLogEntryValue = RaftLogEntryValue:new(query_type, self.collection, query,
+                                                    index, raftClient.localAddress.id,
+                                                    RaftSqliteStore.EnableSyncMode, RaftSqliteStore.thread_name);
+    local bytes = raftLogEntryValue:toBytes();
+
+    raftClient:appendEntries(bytes, function (response, err)
+        local result = (err == nil and response.accepted and "accepted") or "denied"
+        if not (err == nil and response.accepted) then
+          logger.error("the %s request has been %s", query_type, result)
+        else
+          logger.debug("the %s request has been %s", query_type, result)
+        end
+        -- if callbackFunc then
+        -- 	callbackFunc(err);
+        -- end
+      end)
+  end
+
+  if(not callbackFunc and RaftSqliteStore.EnableSyncMode) then
+		return self:WaitForSyncModeReply(nil, index);
+	end
+
+end
+
+
+ 
+-- please note, index will be automatically created for query field if not exist.
+--@param query: key, value pair table, such as {name="abc"}
+--@param callbackFunc: function(err, row) end, where row._id is the internal row id.
+function RaftSqliteStore:findOne(query, callbackFunc)
+  return self:Send("findOne", query, callbackFunc)
+end
+
+ 
+-- find will not automatically create index on query fields. 
+-- Use findOne for fast index-based search. This function simply does a raw search, if no index is found on query string.
+-- @param query: key, value pair table, such as {name="abc"}. if nil or {}, it will return all the rows
+-- @param callbackFunc: function(err, rows) end, where rows is array of rows found
+function RaftSqliteStore:find(query, callbackFunc)
+    return self:Send("find", query, callbackFunc)
+end
+
+ 
+-- @param query: key, value pair table, such as {name="abc"}. 
+-- @param callbackFunc: function(err, count) end
+function RaftSqliteStore:deleteOne(query, callbackFunc)
+    return self:Send("deleteOne", query, callbackFunc)
+end
+
+-- delete multiple records
+-- @param query: key, value pair table, such as {name="abc"}. 
+-- @param callbackFunc: function(err, count) end
+function RaftSqliteStore:delete(query, callbackFunc)
+    return self:Send("delete", query, callbackFunc)
+end
+
+ 
+-- this function will assume query contains at least one valid index key. 
+-- it will not auto create index if key does not exist.
+-- @param query: key, value pair table, such as {name="abc"}. 
+-- @param update: additional fields to be merged with existing data; this can also be callbackFunc
+function RaftSqliteStore:updateOne(query, update, callbackFunc)
+    return self:Send("updateOne", {query = query, update = update}, callbackFunc)
+end
+
+ 
+-- Replaces a single document within the collection based on the query filter.
+-- it will not auto create index if key does not exist.
+-- @param query: key, value pair table, such as {name="abc"}. 
+-- @param replacement: wholistic fields to be replace any existing doc. 
+function RaftSqliteStore:replaceOne(query, replacement, callbackFunc)
+    return self:Send("replaceOne", {query = query, replacement = replacement}, callbackFunc)
+end
+
+
+-- update multiple records, see also updateOne()
+function RaftSqliteStore:update(query, update, callbackFunc)
+    return self:Send("update", {query = query, update = update}, callbackFunc)
+end
+
+ 
+-- if there is already one ore more records with query, this function falls back to updateOne().
+-- otherwise it will insert and return full data with internal row _id.
+-- @param query: nil or query fields. if it contains query fields, it will first do a findOne(), 
+-- if there is record, this function actually falls back to updateOne. 
+function RaftSqliteStore:insertOne(query, update, callbackFunc)
+    return self:Send("insertOne", {query = query, update = update}, callbackFunc)
+end
+
+ 
+-- counting the number of rows in a query. this will always do a table scan using an index. 
+-- avoiding calling this function for big table. 
+-- @param callbackFunc: function(err, count) end
+function RaftSqliteStore:count(query, callbackFunc)
+    return self:Send("count", query, callbackFunc)
+end
+
+ 
+-- normally one does not need to call this function.
+-- the store should flush at fixed interval.
+-- @param callbackFunc: function(err, fFlushed) end
+function RaftSqliteStore:flush(query, callbackFunc)
+    return self:Send("flush", query, callbackFunc)
+end
+
+
+-- @param query: {"indexName"}
+-- @param callbackFunc: function(err, bRemoved) end
+function RaftSqliteStore:removeIndex(query, callbackFunc)
+    return self:Send("removeIndex", query, callbackFunc)
+end
+
+
+
+-- after issuing an really important group of commands, and you want to ensure that 
+-- these commands are actually successful like a transaction, the client can issue a waitflush 
+-- command to check if the previous commands are successful. Please note that waitflush command 
+-- may take up to 3 seconds or RaftSqliteStore.AutoFlushInterval to return. 
+-- @param callbackFunc: function(err, fFlushed) end
+function RaftSqliteStore:waitflush(query, callbackFunc, timeout)
+    return self:Send("waitflush", query, callbackFunc)
+end
+
+
+-- this is usually used for changing database settings, such as cache size and sync mode. 
+-- this function is specific to store implementation. 
+-- @param query: string or {sql=string, CacheSize=number, IgnoreOSCrash=bool, IgnoreAppCrash=bool} 
+function RaftSqliteStore:exec(query, callbackFunc)
+    if(type(query) == "table") then
+      -- also make the caller's message queue size twice as big at least
+      if(query.QueueSize) then
+        local value = query.QueueSize*2;
+        if(__rts__:GetMsgQueueSize() < value) then
+          __rts__:SetMsgQueueSize(value);
+          LOG.std(nil, "system", "NPL", "NPL input queue size of thread (%s) is changed to %d", __rts__:GetName(), value);
+        end
+      end
+      if(query.SyncMode~=nil) then
+        RaftSqliteStore.EnableSyncMode = query.SyncMode;
+        LOG.std(nil, "system", "TableDatabase", "sync mode api is %s in thread %s", query.SyncMode and "enabled" or "disabled", __rts__:GetName());
+      end
+    end
+
+    return self:Send("exec", query, callbackFunc)
+end
+
+
+-- this function never reply. the client will always timeout
+function RaftSqliteStore:silient(query, callbackFunc)
+    return self:Send("silient", query, callbackFunc)
+end
+
+ 
+function RaftSqliteStore:makeEmpty(query, callbackFunc)
+    return self:Send("makeEmpty", query, callbackFunc)
 end

--- a/npl_mod/TableDB/RaftSqliteStore.lua
+++ b/npl_mod/TableDB/RaftSqliteStore.lua
@@ -446,3 +446,8 @@ end
 function RaftSqliteStore:makeEmpty(query, callbackFunc)
     return self:Send("makeEmpty", query, callbackFunc)
 end
+
+
+function RaftSqliteStore:Close()
+    return self:Send("close", {}, function() end);
+end

--- a/npl_mod/TableDB/RaftSqliteStore.lua
+++ b/npl_mod/TableDB/RaftSqliteStore.lua
@@ -1,7 +1,7 @@
 --[[
 Title: base class for store
 Author(s): liuluheng, 
-Date: 2017/8/31
+Date: 2017/7/31
 Desc: 
 use the lib:
 ------------------------------------------------------------

--- a/npl_mod/TableDB/RaftSqliteStore.lua
+++ b/npl_mod/TableDB/RaftSqliteStore.lua
@@ -1,16 +1,8 @@
 --[[
 Title: base class for store
-Author(s): LiXizhi, 
-Date: 2016/5/11
-Desc: Derived class should implement at least following functions for the database store provider.
-virtual functions:
-  findOne
-  find
-  deleteOne
-  updateOne
-  insertOne
-  removeIndex
-
+Author(s): liuluheng, 
+Date: 2017/8/31
+Desc: 
 use the lib:
 ------------------------------------------------------------
 NPL.load("(gl)npl_mod/TableDB/RaftSqliteStore.lua");
@@ -18,438 +10,73 @@ local RaftSqliteStore = commonlib.gettable("TableDB.RaftSqliteStore");
 ------------------------------------------------------------
 ]]
 
-NPL.load("(gl)script/ide/System/Database/StorageProvider.lua");
-local StorageProvider = commonlib.gettable("System.Database.StorageProvider");
-NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
-local util = commonlib.gettable("System.Compiler.lib.util")
-NPL.load("(gl)npl_mod/TableDB/RaftLogEntryValue.lua");
-local RaftLogEntryValue = commonlib.gettable("TableDB.RaftLogEntryValue");
-NPL.load("(gl)npl_mod/Raft/ServerStateManager.lua");
-local ServerStateManager = commonlib.gettable("Raft.ServerStateManager");
-NPL.load("(gl)npl_mod/TableDB/RaftTableDBStateMachine.lua");
-local RaftTableDBStateMachine = commonlib.gettable("TableDB.RaftTableDBStateMachine");
-NPL.load("(gl)npl_mod/Raft/RaftClient.lua");
-local RaftClient = commonlib.gettable("Raft.RaftClient");
-local LoggerFactory = NPL.load("(gl)npl_mod/Raft/LoggerFactory.lua");
-local logger = LoggerFactory.getLogger("RaftSqliteStore")
 
-local RaftSqliteStore = commonlib.inherit(commonlib.gettable("System.Database.Store"), commonlib.gettable("TableDB.RaftSqliteStore"));
+NPL.load("(gl)script/ide/commonlib.lua");
+NPL.load("(gl)script/sqlite/sqlite3.lua");
 
-local callbackQueue = {};
-local raftClient;
+NPL.load("(gl)script/ide/System/Database/SqliteStore.lua");
+local SqliteStore = commonlib.gettable("System.Database.SqliteStore");
+local RaftSqliteStore = commonlib.inherit(SqliteStore, commonlib.gettable("TableDB.RaftSqliteStore"));
 
-RaftSqliteStore.name = "raft";
-RaftSqliteStore.thread_name = format("(%s)", __rts__:GetName());
-
-function RaftSqliteStore:createRaftClient(baseDir, host, port, id, threadName)
-  local baseDir = baseDir or "./"
-  local stateManager = ServerStateManager:new(baseDir);
-  local config = stateManager:loadClusterConfiguration();
-
-  local localAddress = {
-    host = host or "localhost",
-    port = port or "9004",
-    id = id or "server4:",
-  }
-
-  if #localAddress.id < 4 then
-    localAddress.id = format("server%s:", localAddress.id)
-  end
-
-  rtdb = RaftTableDBStateMachine:new(baseDir, localAddress.host, localAddress.port, threadName)
-  
-  NPL.StartNetServer(localAddress.host, localAddress.port);
-
-  rtdb:start2(self)
-  raftClient = RaftClient:new(localAddress, RTDBRequestRPC, config, LoggerFactory)
-
-  self:connect(self, {rootFolder = "dummyDatabase/"});
-
-
-end
-
-function RaftSqliteStore:setRaftClient(c)
-  raftClient = c
-end
-
-function RaftSqliteStore:getRaftClient()
-  return raftClient;
-end
+local follower_dbs = {}
 
 function RaftSqliteStore:ctor()
-  self.stats = {
-    select = 0,
-    update = 0,
-    insert = 0,
-    delete = 0,
-  };
-
-  -- StorageProvider:RegisterStorageClass(self.name, self)
-
 end
 
 function RaftSqliteStore:init(collection, init_args)
+  RaftSqliteStore._super.init(self, collection);
+  local dbName = self.kFileName
   self.collection = collection;
-  print(util.table_tostring(init_args))
-  if not raftClient then
-    self:createRaftClient(unpack(init_args));
-  end
+
+  self._db:set_wal_page_hook(function (page_data, pgno, nTruncate, isCommit)
+    local db2 = follower_dbs[collection:GetName()];
+    if not db2 then
+      db2 = sqlite3.open(dbName .. "2")
+      db2:exec("PRAGMA journal_mode=WAL;");
+      db2:exec("PRAGMA synchronous=NORMAL;");
+      follower_dbs[collection:GetName()] = db2;
+    end
+    -- followers simply append wal, no need to worry about the meta data
+    print(format("wal_page_hook: pgSize %d, pgno %d, nTruncate %d, isCommit %d", #page_data, pgno, nTruncate, isCommit))
+    db2:wal_inject_page(page_data, pgno, nTruncate, isCommit)
+    return 1
+  end)
+
+  self._db:set_wal_checkpoint_hook(function ()
+    print("wal_checkpoint_hook")
+    follower_dbs[self.collection:GetName()]:wal_checkpoint("main")
+    return 1
+  end)
+
+  -- create meta data in sqliteStore
+	self:Begin();
+		-- drop all tables. 
+		self:DropAllMetaTables();
+	
+		-- create all tables
+		self:CreateTables();
+
+		-- insert version infos
+		local insert_stmt = assert(self._db:prepare("INSERT INTO SystemInfo (Name, Value) VALUES(?, ?)"));
+		insert_stmt:bind("version", SqliteStore.kCurrentVersion);
+		insert_stmt:exec();
+		insert_stmt:bind("author", "NPLRuntime");
+		insert_stmt:exec();
+		insert_stmt:bind("name", self:GetCollection():GetName());
+		insert_stmt:exec();
+		insert_stmt:close();
+
+	self:End();
+	self:FlushAll();
+	LOG.std(nil, "TableDB", "RaftSqliteStore", "%s is recreated for raft", self.kFileName);
+	self:ValidateDB();
+
   return self;
 end
 
-
-
--- how many seconds to wait on busy database, before we send "queue_full" error. This parameter only takes effect when self.WaitOnBusyDB is true.
-RaftSqliteStore.MaxWaitSeconds = 5;
--- default time out for a given request. default to 5 seconds
-RaftSqliteStore.DefaultTimeout = 5000;
--- internal timer period
-RaftSqliteStore.monitorPeriod = 5000;
--- true to log everything.
-RaftSqliteStore.debug_log = false;
-
-function RaftSqliteStore:OneTimeInit()
-  if(self.inited) then
-    return;
-  end
-  self.inited = true;
-  NPL.load("(gl)script/ide/timer.lua");
-  self.mytimer = commonlib.Timer:new({callbackFunc = function(timer)
-    self:CheckTimedOutRequests();
-  end})
-  self.mytimer:Change(self.monitorPeriod, self.monitorPeriod);
-end
-
--- remove any timed out request.
-function RaftSqliteStore:CheckTimedOutRequests()
-  local curTime = ParaGlobal.timeGetTime();
-  local timeout_pool;
-  for i, cb in pairs(callbackQueue) do
-    if((curTime - cb.startTime) > (cb.timeout or self.DefaultTimeout) ) then
-      timeout_pool = timeout_pool or {};
-      timeout_pool[i] = cb;
-    end
-  end
-  if(timeout_pool) then
-    for i, cb in pairs(timeout_pool) do
-      callbackQueue[i] = nil;
-      if(cb.callbackFunc) then
-        cb.callbackFunc("timeout", nil);
-      end
-    end
-  end
-end
-
-local next_id = 0;
-function getNextId()
-  next_id = next_id + 1;
-  return next_id;
-end
--- get next callback pool index. may return nil if max queue size is reached. 
--- @return index or nil
-function RaftSqliteStore:PushCallback(callbackFunc, timeout)
-  -- if(not callbackFunc) then
-  --   return -1;
-  -- end
-  local index = getNextId();
-  callbackQueue[index] = {callbackFunc = callbackFunc, startTime = ParaGlobal.timeGetTime(), timeout=timeout};
-  return index;
-end
-
-function RaftSqliteStore:PopCallback(index)
-  if(index) then
-    local cb = callbackQueue[index];
-    if(cb) then
-      callbackQueue[index] = nil;
-      return cb;
-    end
-  end
-end
-
--- return err, data.
-function RaftSqliteStore:WaitForSyncModeReply(timeout, cb_index)
-  timeout = timeout or self.DefaultTimeout;
-  local thread = __rts__;
-  local reply_msg;
-  local startTime = ParaGlobal.timeGetTime();
-  while (not reply_msg) do
-    local nSize = thread:GetCurrentQueueSize();
-    for i=0, nSize-1 do
-      local msg = thread:PeekMessage(i, {filename=true});
-      if(msg.filename == "Rpc/RTDBRequestRPC.lua") then
-        local msg = thread:PopMessageAt(i, {filename=true, msg=true});
-        local out_msg = msg.msg;
-        logger.trace("recv msg:%s", util.table_tostring(out_msg));
-        -- we use this only in connect and we should ensure connect's cb_index should be -1
-        if not RaftSqliteStore.EnableSyncMode then
-          raftClient.HandleResponse(nil, out_msg.msg);
-        else
-          RaftSqliteStore:handleResponse(out_msg.msg);
-        end
-        if(cb_index and out_msg.msg and out_msg.msg.cb_index == cb_index) or
-           (cb_index == nil and out_msg.msg and out_msg.msg.destination and out_msg.msg.destination ~= -1) then
-          logger.debug("got the correct msg");
-          reply_msg = out_msg.msg;
-          break;
-        end
-      end
-    end
-    if( (ParaGlobal.timeGetTime() - startTime) > timeout) then
-      LOG.std(nil, "warn", "RaftSqliteStore", "timed out");
-      return "timeout", nil;
-    end
-    if(reply_msg == nil) then
-      if(ParaEngine.GetAttributeObject():GetField("HasClosingRequest", false) == true) then
-        return "app_exit", nil;
-      end
-      if(thread:GetCurrentQueueSize() == nSize) then
-        thread:WaitForMessage(nSize);
-      end
-    end
-  end
-  if(reply_msg) then
-    return reply_msg.err, reply_msg.data;
-  end
-end
-
-
-function RaftSqliteStore:handleResponse(msg)
-  local cb = self:PopCallback(msg.cb_index);
-  if(cb and cb.callbackFunc) then
-    cb.callbackFunc(msg.err, msg.data);
-  end
-end
-
--- called when a single command is finished. 
-function RaftSqliteStore:CommandTick(commandname)
-  if(commandname) then
-    self:AddStat(commandname, 1);
-  end
-end
-
-function RaftSqliteStore:GetCollection()
-  return self.collection;
-end
-
-function RaftSqliteStore:GetStats()
-  return self.stats;
-end
-
--- add statistics for a given name
--- @param name: such as "select", "update", "insert", "delete"
--- @param count: if nil it is 1.
-function RaftSqliteStore:AddStat(name, count)
-  name = name or "unknown";
-  local stats = self:GetStats();
-  stats[name] = (stats[name] or 0) + (count or 1);
-end
-
--- get current count for a given stats name
--- @param name: such as "select", "update", "insert", "delete"
-function RaftSqliteStore:GetStat(name)
-  name = name or "unknown";
-  local stats = self:GetStats();
-  return (stats[name] or 0);
-end
-
-function RaftSqliteStore:InvokeCallback(callbackFunc, err, data)
-  if(callbackFunc) then
-    callbackFunc(err, data);
-  else
-    return data;
-  end
-end
-
-
-function RaftSqliteStore:connect(db, data, callbackFunc)
-  local query_type = "connect"
-  local collection = {
-    ToData = function (...)	end,
-  }
-
-  local query = {
-    rootFolder = data.rootFolder,
-  }
-
-  local raftLogEntryValue = RaftLogEntryValue:new(query_type, collection, query, -1,
-                                                  raftClient.localAddress.id,
-                                                  RaftSqliteStore.EnableSyncMode,
-                                                  RaftSqliteStore.thread_name);
-  local bytes = raftLogEntryValue:toBytes();
-
-  -- if not raftClient then
-  --   self:createRaftClient()
-  -- end
-
-  raftClient:appendEntries(bytes, function (response, err)
-      local result = (err == nil and response.accepted and "accepted") or "denied"
-      logger.info("the %s request has been %s", query_type, result)
-      if callbackFunc then
-        callbackFunc(err, response.data);
-      end
-    end)
-
-  self:WaitForSyncModeReply(10000);
-end
-
-
-function RaftSqliteStore:Send(query_type, query, callbackFunc)
-  self:OneTimeInit();
-  local index = self:PushCallback(callbackFunc);
-  if(index) then
-    local raftLogEntryValue = RaftLogEntryValue:new(query_type, self.collection, query,
-                                                    index, raftClient.localAddress.id,
-                                                    RaftSqliteStore.EnableSyncMode, RaftSqliteStore.thread_name);
-    local bytes = raftLogEntryValue:toBytes();
-
-    raftClient:appendEntries(bytes, function (response, err)
-        local result = (err == nil and response.accepted and "accepted") or "denied"
-        if not (err == nil and response.accepted) then
-          logger.error("the %s request has been %s", query_type, result)
-        else
-          logger.debug("the %s request has been %s", query_type, result)
-        end
-        -- if callbackFunc then
-        -- 	callbackFunc(err);
-        -- end
-      end)
-  end
-
-  if(not callbackFunc and RaftSqliteStore.EnableSyncMode) then
-		return self:WaitForSyncModeReply(nil, index);
-	end
-
-end
-
-
- 
--- please note, index will be automatically created for query field if not exist.
---@param query: key, value pair table, such as {name="abc"}
---@param callbackFunc: function(err, row) end, where row._id is the internal row id.
-function RaftSqliteStore:findOne(query, callbackFunc)
-  return self:Send("findOne", query, callbackFunc)
-end
-
- 
--- find will not automatically create index on query fields. 
--- Use findOne for fast index-based search. This function simply does a raw search, if no index is found on query string.
--- @param query: key, value pair table, such as {name="abc"}. if nil or {}, it will return all the rows
--- @param callbackFunc: function(err, rows) end, where rows is array of rows found
-function RaftSqliteStore:find(query, callbackFunc)
-    return self:Send("find", query, callbackFunc)
-end
-
- 
--- @param query: key, value pair table, such as {name="abc"}. 
--- @param callbackFunc: function(err, count) end
-function RaftSqliteStore:deleteOne(query, callbackFunc)
-    return self:Send("deleteOne", query, callbackFunc)
-end
-
--- delete multiple records
--- @param query: key, value pair table, such as {name="abc"}. 
--- @param callbackFunc: function(err, count) end
-function RaftSqliteStore:delete(query, callbackFunc)
-    return self:Send("delete", query, callbackFunc)
-end
-
- 
--- this function will assume query contains at least one valid index key. 
--- it will not auto create index if key does not exist.
--- @param query: key, value pair table, such as {name="abc"}. 
--- @param update: additional fields to be merged with existing data; this can also be callbackFunc
-function RaftSqliteStore:updateOne(query, update, callbackFunc)
-    return self:Send("updateOne", {query = query, update = update}, callbackFunc)
-end
-
- 
--- Replaces a single document within the collection based on the query filter.
--- it will not auto create index if key does not exist.
--- @param query: key, value pair table, such as {name="abc"}. 
--- @param replacement: wholistic fields to be replace any existing doc. 
-function RaftSqliteStore:replaceOne(query, replacement, callbackFunc)
-    return self:Send("replaceOne", {query = query, replacement = replacement}, callbackFunc)
-end
-
-
--- update multiple records, see also updateOne()
-function RaftSqliteStore:update(query, update, callbackFunc)
-    return self:Send("update", {query = query, update = update}, callbackFunc)
-end
-
- 
--- if there is already one ore more records with query, this function falls back to updateOne().
--- otherwise it will insert and return full data with internal row _id.
--- @param query: nil or query fields. if it contains query fields, it will first do a findOne(), 
--- if there is record, this function actually falls back to updateOne. 
-function RaftSqliteStore:insertOne(query, update, callbackFunc)
-    return self:Send("insertOne", {query = query, update = update}, callbackFunc)
-end
-
- 
--- counting the number of rows in a query. this will always do a table scan using an index. 
--- avoiding calling this function for big table. 
--- @param callbackFunc: function(err, count) end
-function RaftSqliteStore:count(query, callbackFunc)
-    return self:Send("count", query, callbackFunc)
-end
-
- 
--- normally one does not need to call this function.
--- the store should flush at fixed interval.
--- @param callbackFunc: function(err, fFlushed) end
-function RaftSqliteStore:flush(query, callbackFunc)
-    return self:Send("flush", query, callbackFunc)
-end
-
-
--- @param query: {"indexName"}
--- @param callbackFunc: function(err, bRemoved) end
-function RaftSqliteStore:removeIndex(query, callbackFunc)
-    return self:Send("removeIndex", query, callbackFunc)
-end
-
-
-
--- after issuing an really important group of commands, and you want to ensure that 
--- these commands are actually successful like a transaction, the client can issue a waitflush 
--- command to check if the previous commands are successful. Please note that waitflush command 
--- may take up to 3 seconds or RaftSqliteStore.AutoFlushInterval to return. 
--- @param callbackFunc: function(err, fFlushed) end
-function RaftSqliteStore:waitflush(query, callbackFunc, timeout)
-    return self:Send("waitflush", query, callbackFunc)
-end
-
-
--- this is usually used for changing database settings, such as cache size and sync mode. 
--- this function is specific to store implementation. 
--- @param query: string or {sql=string, CacheSize=number, IgnoreOSCrash=bool, IgnoreAppCrash=bool} 
-function RaftSqliteStore:exec(query, callbackFunc)
-    if(type(query) == "table") then
-      -- also make the caller's message queue size twice as big at least
-      if(query.QueueSize) then
-        local value = query.QueueSize*2;
-        if(__rts__:GetMsgQueueSize() < value) then
-          __rts__:SetMsgQueueSize(value);
-          LOG.std(nil, "system", "NPL", "NPL input queue size of thread (%s) is changed to %d", __rts__:GetName(), value);
-        end
-      end
-      if(query.SyncMode~=nil) then
-        RaftSqliteStore.EnableSyncMode = query.SyncMode;
-        LOG.std(nil, "system", "TableDatabase", "sync mode api is %s in thread %s", query.SyncMode and "enabled" or "disabled", __rts__:GetName());
-      end
-    end
-
-    return self:Send("exec", query, callbackFunc)
-end
-
-
--- this function never reply. the client will always timeout
-function RaftSqliteStore:silient(query, callbackFunc)
-    return self:Send("silient", query, callbackFunc)
-end
-
- 
-function RaftSqliteStore:makeEmpty(query, callbackFunc)
-    return self:Send("makeEmpty", query, callbackFunc)
+function RaftSqliteStore:Close()
+    RaftSqliteStore._super.Close(self)
+    -- send close
+    follower_dbs[self.collection:GetName()]:close()
+    follower_dbs[self.collection:GetName()] = nil;
 end

--- a/npl_mod/TableDB/RaftSqliteStore.lua
+++ b/npl_mod/TableDB/RaftSqliteStore.lua
@@ -17,8 +17,7 @@ NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
 local util = commonlib.gettable("System.Compiler.lib.util")
 NPL.load("(gl)npl_mod/TableDB/RaftLogEntryValue.lua");
 local RaftLogEntryValue = commonlib.gettable("TableDB.RaftLogEntryValue");
-NPL.load("(gl)npl_mod/Raft/FileBasedServerStateManager.lua");
-local FileBasedServerStateManager = commonlib.gettable("Raft.FileBasedServerStateManager");
+
 NPL.load("(gl)npl_mod/TableDB/RaftTableDBStateMachine.lua");
 local RaftTableDBStateMachine = commonlib.gettable("TableDB.RaftTableDBStateMachine");
 NPL.load("(gl)npl_mod/Raft/RaftClient.lua");
@@ -34,9 +33,20 @@ local raftClient;
 RaftSqliteStore.name = "raft";
 RaftSqliteStore.thread_name = format("(%s)", __rts__:GetName());
 
-function RaftSqliteStore:createRaftClient(baseDir, host, port, id, threadName, rootFolder)
+function RaftSqliteStore:createRaftClient(baseDir, host, port, id, threadName, rootFolder, userFile)
+  local ServerStateManager;
+  if userFile then
+    NPL.load("(gl)npl_mod/Raft/FileBasedServerStateManager.lua");
+    local FileBasedServerStateManager = commonlib.gettable("Raft.FileBasedServerStateManager");
+    ServerStateManager = FileBasedServerStateManager;
+  else
+    NPL.load("(gl)npl_mod/Raft/SqliteBasedServerStateManager.lua");
+    local SqliteBasedServerStateManager = commonlib.gettable("Raft.SqliteBasedServerStateManager");
+    ServerStateManager = SqliteBasedServerStateManager;
+  end
+
   local baseDir = baseDir or "./"
-  local stateManager = FileBasedServerStateManager:new(baseDir);
+  local stateManager = ServerStateManager:new(baseDir);
   local config = stateManager:loadClusterConfiguration();
 
   local localAddress = {

--- a/npl_mod/TableDB/RaftSqliteStore.lua
+++ b/npl_mod/TableDB/RaftSqliteStore.lua
@@ -33,9 +33,9 @@ local raftClient;
 RaftSqliteStore.name = "raft";
 RaftSqliteStore.thread_name = format("(%s)", __rts__:GetName());
 
-function RaftSqliteStore:createRaftClient(baseDir, host, port, id, threadName, rootFolder, userFile)
+function RaftSqliteStore:createRaftClient(baseDir, host, port, id, threadName, rootFolder, useFile)
   local ServerStateManager;
-  if userFile then
+  if useFile then
     NPL.load("(gl)npl_mod/Raft/FileBasedServerStateManager.lua");
     local FileBasedServerStateManager = commonlib.gettable("Raft.FileBasedServerStateManager");
     ServerStateManager = FileBasedServerStateManager;

--- a/npl_mod/TableDB/RaftSqliteStore.lua
+++ b/npl_mod/TableDB/RaftSqliteStore.lua
@@ -17,8 +17,8 @@ NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
 local util = commonlib.gettable("System.Compiler.lib.util")
 NPL.load("(gl)npl_mod/TableDB/RaftLogEntryValue.lua");
 local RaftLogEntryValue = commonlib.gettable("TableDB.RaftLogEntryValue");
-NPL.load("(gl)npl_mod/Raft/ServerStateManager.lua");
-local ServerStateManager = commonlib.gettable("Raft.ServerStateManager");
+NPL.load("(gl)npl_mod/Raft/FileBasedServerStateManager.lua");
+local FileBasedServerStateManager = commonlib.gettable("Raft.FileBasedServerStateManager");
 NPL.load("(gl)npl_mod/TableDB/RaftTableDBStateMachine.lua");
 local RaftTableDBStateMachine = commonlib.gettable("TableDB.RaftTableDBStateMachine");
 NPL.load("(gl)npl_mod/Raft/RaftClient.lua");
@@ -36,7 +36,7 @@ RaftSqliteStore.thread_name = format("(%s)", __rts__:GetName());
 
 function RaftSqliteStore:createRaftClient(baseDir, host, port, id, threadName, rootFolder)
   local baseDir = baseDir or "./"
-  local stateManager = ServerStateManager:new(baseDir);
+  local stateManager = FileBasedServerStateManager:new(baseDir);
   local config = stateManager:loadClusterConfiguration();
 
   local localAddress = {

--- a/npl_mod/TableDB/RaftTableDBStateMachine.lua
+++ b/npl_mod/TableDB/RaftTableDBStateMachine.lua
@@ -94,12 +94,12 @@ function RaftTableDBStateMachine:start(raftMessageSender)
     
     self.db = TableDatabase:new();
     -- start tdb
-    NPL.load("(gl)script/ide/System/Database/IORequest.lua");
-    local IORequest = commonlib.gettable("System.Database.IORequest");
-    IORequest:Send("init_tdb", self.db);
+    -- NPL.load("(gl)script/ide/System/Database/IORequest.lua");
+    -- local IORequest = commonlib.gettable("System.Database.IORequest");
+    -- IORequest:Send("init_tdb", self.db);
     
-    self.snapshotThread = "Snapshot";
-    NPL.CreateRuntimeState(self.snapshotThread, 0):Start();
+    -- self.snapshotThread = "Snapshot";
+    -- NPL.CreateRuntimeState(self.snapshotThread, 0):Start();
 --     local this = self
 --     Rpc:new():init("SnapshotRPC", function(self, msg)
 --             this.logger.info(util.table_tostring(msg))
@@ -155,6 +155,12 @@ function RaftTableDBStateMachine:commit(logIndex, data)
             self.logger.info("connected to %s", data.rootFolder);
         end);
     end
+
+    -- if self.db:GetRootFolder() == "temp/TableDatabase/" then
+    --     self.db:connect(data.rootFolder, function (...)
+    --         self.logger.info("connected to %s", data.rootFolder);
+    --     end);
+    -- end
 
     --add to collections
     if not self.collections[data.collectionName] then

--- a/npl_mod/TableDB/RaftTableDBStateMachine.lua
+++ b/npl_mod/TableDB/RaftTableDBStateMachine.lua
@@ -44,7 +44,7 @@ function RaftTableDBStateMachine:new(baseDir, ip, listeningPort, threadName)
         commitIndex = 0,
         messageSender = nil,
         MaxWaitSeconds = 5,
-        latestCommand = -1,
+        latestCommand = -2,
         
         threadName = threadName,
         
@@ -79,7 +79,9 @@ function RaftTableDBStateMachine:start(raftMessageSender)
     self.messageSender = raftMessageSender;
     
     -- for init connect
-    Rpc:new():init("RaftRequestRPCInit");
+    Rpc:new():init("RaftRequestRPCInit", function (...)
+        print("RaftRequestRPCInit callback")
+    end);
     RaftRequestRPCInit.remoteThread = self.threadName;
     RaftRequestRPCInit:MakePublic();
 

--- a/npl_mod/TableDB/RaftTableDBStateMachine.lua
+++ b/npl_mod/TableDB/RaftTableDBStateMachine.lua
@@ -44,7 +44,7 @@ function RaftTableDBStateMachine:new(baseDir, ip, listeningPort, threadName)
         commitIndex = 0,
         messageSender = nil,
         MaxWaitSeconds = 5,
-        latestCommand = -1,
+        latestCommand = -2,
         
         threadName = threadName,
         
@@ -144,10 +144,44 @@ end
 ]]
 --
 function RaftTableDBStateMachine:commit(logIndex, data)
+    self.logger.info("commit:%d", logIndex);
+    
+	local config_path = data.rootFolder .. "/tabledb.config.xml";
+    if not ParaIO.DoesFileExist(config_path) then
+        self:createSqliteWALStoreConfig(data.rootFolder);
+        self.db:connect(data.rootFolder, function (...)
+            self.logger.info("connected to %s", data.rootFolder);
+        end);
+    end
+    local collection = self.db[data.collectionName];
+    collection:injectWALPage(data);
+
+    self.commitIndex = logIndex;
+end
+
+--[[
+* Rollback a preCommit item at index {@code logIndex}
+* @param logIndex log index to be rolled back
+* @param data
+]]
+--
+function RaftTableDBStateMachine:rollback(logIndex, data)
+-- need more thought here
+-- rollback on last root pair
+-- self._db:exec("ROLLBACK");
+end
+
+--[[
+* PreCommit a log entry at log index {@code logIndex}
+* @param logIndex the log index to commit
+* @param data
+]]
+--
+function RaftTableDBStateMachine:preCommit(logIndex, data)
     -- data is logEntry.value
     local raftLogEntryValue = RaftLogEntryValue:fromBytes(data);
 
-    self.logger.info("commit:%s", util.table_tostring(raftLogEntryValue))
+    self.logger.info("preCommit:%s", util.table_tostring(raftLogEntryValue))
 
     local this = self;
     local cbFunc = function(err, data, re_exec)
@@ -176,12 +210,15 @@ function RaftTableDBStateMachine:commit(logIndex, data)
     
     -- a dedicated IOThread
     if raftLogEntryValue.query_type == "connect" then
-        -- self.db:connect(raftLogEntryValue.query.rootFolder, cbFunc);
+        -- raftLogEntryValue.collection.db is nil when query_type is connect
+        -- we should create table.config.xml here and make the storageProvider to SqliteWALStore
+        self:createSqliteWALStoreConfig(raftLogEntryValue.query.rootFolder);
+        self.db:connect(raftLogEntryValue.query.rootFolder, cbFunc);
     else
         if raftLogEntryValue.enableSyncMode then
             self.db:EnableSyncMode(true);
         end
-        self.db:connect(raftLogEntryValue.collection.db);
+        -- self.db:connect(raftLogEntryValue.collection.db);
         local collection = self.db[raftLogEntryValue.collection.name];
         
         --add to collections
@@ -213,31 +250,6 @@ function RaftTableDBStateMachine:commit(logIndex, data)
     
     self.latestCommand = raftLogEntryValue.cb_index;
     self.commitIndex = logIndex;
-end
-
---[[
-* Rollback a preCommit item at index {@code logIndex}
-* @param logIndex log index to be rolled back
-* @param data
-]]
---
-function RaftTableDBStateMachine:rollback(logIndex, data)
--- need more thought here
--- rollback on last root pair
--- self._db:exec("ROLLBACK");
-end
-
---[[
-* PreCommit a log entry at log index {@code logIndex}
-* @param logIndex the log index to commit
-* @param data
-]]
---
-function RaftTableDBStateMachine:preCommit(logIndex, data)
--- add cb_index to response
--- local raftLogEntryValue = RaftLogEntryValue:fromBytes(data);
--- self.messages[raftLogEntryValue.cb_index] = raftLogEntryValue;
--- self.pendingMessages[raftLogEntryValue.cb_index] = raftLogEntryValue;
 end
 
 --[[
@@ -441,16 +453,29 @@ function RaftTableDBStateMachine:processMessage(message)
 end
 
 
-function RaftTableDBStateMachine:addMessage(message)
-    index = string.find(message, ':');
-    if (index == nil) then
-        return;
-    end
-    
-    key = string.sub(message, 1, index - 1);
-    self.messages[key] = message;
-    self.pendingMessages[key] = nil;
+function RaftTableDBStateMachine:createSqliteWALStoreConfig(rootFolder)
+	NPL.load("(gl)script/ide/commonlib.lua");
+	NPL.load("(gl)script/ide/LuaXML.lua");
+	local config = { 
+		name = "tabledb", 
+		{
+			name = "providers", 
+			{ name = "provider", attr = { name = "sqliteWAL", type = "TableDB.SqliteWALStore", file = "(g1)npl_mod/TableDB/SqliteWALStore.lua" }, "" }
+		},
+		{
+			name = "tables",
+			{ name = "table", attr = { provider = "sqliteWAL", name = "default" } }, 
+		}
+	}
 
+	local config_path = rootFolder .. "/tabledb.config.xml";
+	local str = commonlib.Lua2XmlString(config, true);
+	ParaIO.CreateDirectory(config_path);
+	local file = ParaIO.open(config_path, "w");
+	if (file:IsValid()) then
+		file:WriteString(str);
+		file:close();
+	end
 end
 
 

--- a/npl_mod/TableDB/RaftTableDBStateMachine.lua
+++ b/npl_mod/TableDB/RaftTableDBStateMachine.lua
@@ -145,6 +145,7 @@ end
 --
 function RaftTableDBStateMachine:commit(logIndex, data)
     self.logger.info("commit:%d", logIndex);
+    data.logIndex = logIndex;
     
 	local config_path = data.rootFolder .. "/tabledb.config.xml";
     if not ParaIO.DoesFileExist(config_path) then

--- a/npl_mod/TableDB/RaftTableDBStateMachine.lua
+++ b/npl_mod/TableDB/RaftTableDBStateMachine.lua
@@ -56,6 +56,7 @@ function RaftTableDBStateMachine:new(baseDir, ip, listeningPort, threadName)
     if not ParaIO.CreateDirectory(o.snapshotStore) then
         o.logger.error("%s dir create error", o.snapshotStore)
     end
+
     return o;
 end
 
@@ -154,6 +155,14 @@ function RaftTableDBStateMachine:commit(logIndex, data)
             self.logger.info("connected to %s", data.rootFolder);
         end);
     end
+
+    --add to collections
+    if not self.collections[data.collectionName] then
+        local collectionPath = data.rootFolder .. data.collectionName;
+        self.logger.trace("add collection %s->%s", data.collectionName, collectionPath)
+        self.collections[data.collectionName] = collectionPath;
+    end
+
     local collection = self.db[data.collectionName];
     collection:injectWALPage(data);
 

--- a/npl_mod/TableDB/RaftTableDBStateMachine.lua
+++ b/npl_mod/TableDB/RaftTableDBStateMachine.lua
@@ -79,9 +79,7 @@ function RaftTableDBStateMachine:start(raftMessageSender)
     self.messageSender = raftMessageSender;
     
     -- for init connect
-    Rpc:new():init("RaftRequestRPCInit", function (...)
-        print("RaftRequestRPCInit callback")
-    end);
+    Rpc:new():init("RaftRequestRPCInit");
     RaftRequestRPCInit.remoteThread = self.threadName;
     RaftRequestRPCInit:MakePublic();
 

--- a/npl_mod/TableDB/SQLHandler.lua
+++ b/npl_mod/TableDB/SQLHandler.lua
@@ -155,7 +155,7 @@ function SQLHandler:handle(data)
     -- a dedicated IOThread
     if raftLogEntryValue.query_type == "connect" then
         -- raftLogEntryValue.collection.db is nil when query_type is connect
-        -- we should create table.config.xml here and make the storageProvider to SqliteWALStore
+        -- we should create tabledb.config.xml here and make the storageProvider to SqliteWALStore
         self:createSqliteWALStoreConfig(raftLogEntryValue.query.rootFolder);
         self.db:connect(raftLogEntryValue.query.rootFolder, cbFunc);
     else

--- a/npl_mod/TableDB/SQLHandler.lua
+++ b/npl_mod/TableDB/SQLHandler.lua
@@ -1,0 +1,243 @@
+--[[
+Title:
+Author: liuluheng
+Date: 2017.04.12
+Desc:
+
+------------------------------------------------------------
+NPL.load("(gl)npl_mod/TableDB/SQLHandler.lua");
+local SQLHandler = commonlib.gettable("TableDB.SQLHandler");
+------------------------------------------------------------
+]]
+--
+
+NPL.load("(gl)script/ide/commonlib.lua");
+NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
+local util = commonlib.gettable("System.Compiler.lib.util")
+NPL.load("(gl)npl_mod/Raft/Rpc.lua");
+local Rpc = commonlib.gettable("Raft.Rpc");
+NPL.load("(gl)npl_mod/TableDB/RaftLogEntryValue.lua");
+local RaftLogEntryValue = commonlib.gettable("TableDB.RaftLogEntryValue");
+NPL.load("(gl)npl_mod/Raft/ServerState.lua");
+local ServerState = commonlib.gettable("Raft.ServerState");
+
+
+
+NPL.load("(gl)script/ide/System/Database/TableDatabase.lua");
+local TableDatabase = commonlib.gettable("System.Database.TableDatabase");
+
+local RaftMessageType = NPL.load("(gl)npl_mod/Raft/RaftMessageType.lua");
+local LoggerFactory = NPL.load("(gl)npl_mod/Raft/LoggerFactory.lua");
+local SQLHandler = commonlib.gettable("TableDB.SQLHandler");
+
+local g_threadName = __rts__:GetName();
+
+-- for function not in class
+local logger = LoggerFactory.getLogger("SQLHandler");
+
+function SQLHandler:new(baseDir, useFile)
+    local ServerStateManager;
+    if useFile then
+        NPL.load("(gl)npl_mod/Raft/FileBasedServerStateManager.lua");
+        local FileBasedServerStateManager = commonlib.gettable("Raft.FileBasedServerStateManager");
+        ServerStateManager = FileBasedServerStateManager;
+    else
+        NPL.load("(gl)npl_mod/Raft/SqliteBasedServerStateManager.lua");
+        local SqliteBasedServerStateManager = commonlib.gettable("Raft.SqliteBasedServerStateManager");
+        ServerStateManager = SqliteBasedServerStateManager;
+    end
+
+
+    local o = {
+        baseDir = baseDir,
+        stateManager = ServerStateManager:new(baseDir),
+        threadName = g_threadName,
+        logger = LoggerFactory.getLogger("SQLHandler"),
+        latestCommand = -2,
+        collections = {},
+    };
+    setmetatable(o, self);
+
+    return o;
+end
+
+function SQLHandler:__index(name)
+    return rawget(self, name) or SQLHandler[name];
+end
+
+function SQLHandler:__tostring()
+    return util.table_tostring(self)
+end
+
+--
+function SQLHandler:start()
+    __rts__:SetMsgQueueSize(50000);
+    local this = self;
+    Rpc:new():init("RaftRequestRPCInit");
+    RaftRequestRPCInit.remoteThread = self.threadName;
+    RaftRequestRPCInit:MakePublic();
+    Rpc:new():init("RTDBRequestRPC", function(self, msg)
+        msg = this:processMessage(msg)
+        return msg;
+    end)
+    RTDBRequestRPC.remoteThread = self.threadName;
+    RTDBRequestRPC:MakePublic();
+    
+    self.db = TableDatabase:new();
+    -- start tdb
+    NPL.load("(gl)script/ide/System/Database/IORequest.lua");
+    local IORequest = commonlib.gettable("System.Database.IORequest");
+    IORequest:Send("init_tdb", self.db);
+
+    self.logger.info("SQLHandler started");
+end
+
+function SQLHandler:processMessage(request)
+    local state = self.stateManager:readState();
+    if not state then
+        return;
+    end
+    local response = {
+        messageType = RaftMessageType.AppendEntriesResponse,
+        source = self.stateManager.serverId,
+        destination = state.votedFor, -- use destination to indicate the leadId
+        term = state.term,
+    }
+    
+    if state.votedFor ~= self.stateManager.serverId then
+        response.accepted = false
+        return response
+    end
+
+    -- the leader executes the SQL, but the followers just append to WAL
+    if request.logEntries and #request.logEntries > 0 then
+        for i, v in ipairs(request.logEntries) do
+            self:handle(v.value);
+        end
+    end
+    
+    response.accepted = true;
+    return response
+end
+
+
+function SQLHandler:handle(data)
+    -- data is logEntry.value
+    local raftLogEntryValue = RaftLogEntryValue:fromBytes(data);
+
+    self.logger.trace("SQL:%s", util.table_tostring(raftLogEntryValue))
+
+    local this = self;
+    local cbFunc = function(err, data, re_exec)
+        local msg = {
+            err = err,
+            data = data,
+            cb_index = raftLogEntryValue.cb_index,
+        }
+
+        this.logger.trace("result:%s", util.table_tostring(msg))
+
+        local remoteAddress = format("%s%s", raftLogEntryValue.callbackThread, raftLogEntryValue.serverId)
+        if not re_exec then
+            this.latestError = err;
+            this.latestData = data;
+        end
+        
+        RTDBRequestRPC(nil, remoteAddress, msg);
+    end;
+
+    if raftLogEntryValue.cb_index <= self.latestCommand then
+        self.logger.info("got a retry msg, %d <= %d", raftLogEntryValue.cb_index, self.latestCommand);
+        cbFunc(this.latestError, this.latestData, true);
+        return;
+    end
+    
+    -- a dedicated IOThread
+    if raftLogEntryValue.query_type == "connect" then
+        -- raftLogEntryValue.collection.db is nil when query_type is connect
+        -- we should create table.config.xml here and make the storageProvider to SqliteWALStore
+        self:createSqliteWALStoreConfig(raftLogEntryValue.query.rootFolder);
+        self.db:connect(raftLogEntryValue.query.rootFolder, cbFunc);
+    else
+        if raftLogEntryValue.enableSyncMode then
+            self.db:EnableSyncMode(true);
+        end
+        -- self.db:connect(raftLogEntryValue.collection.db);
+        local collection = self.db[raftLogEntryValue.collection.name];
+        
+        --add to collections
+        if not self.collections[raftLogEntryValue.collection.name] then
+            local collectionPath = raftLogEntryValue.collection.db .. raftLogEntryValue.collection.name;
+            self.logger.trace("add collection %s->%s", raftLogEntryValue.collection.name, collectionPath)
+            self.collections[raftLogEntryValue.collection.name] = collectionPath;
+            -- self.db.collections:insertOne(nil, {name=raftLogEntryValue.collection.name,path=collectionPath});
+        -- self.collections[raftLogEntryValue.collection.name] = collection
+        end
+        
+        -- NOTE: this may not work when the query field named "update" or "replacement"
+        if raftLogEntryValue.query.update or raftLogEntryValue.query.replacement then
+            if raftLogEntryValue.enableSyncMode then
+                cbFunc(collection[raftLogEntryValue.query_type](collection, raftLogEntryValue.query.query,
+                    raftLogEntryValue.query.update or raftLogEntryValue.query.replacement));
+            else
+                collection[raftLogEntryValue.query_type](collection, raftLogEntryValue.query.query,
+                    raftLogEntryValue.query.update or raftLogEntryValue.query.replacement,
+                    cbFunc);
+            end
+        else
+            if raftLogEntryValue.enableSyncMode then
+                cbFunc(collection[raftLogEntryValue.query_type](collection, raftLogEntryValue.query));
+            else
+                collection[raftLogEntryValue.query_type](collection, raftLogEntryValue.query, cbFunc);
+            end
+        end
+    end
+    
+    self.latestCommand = raftLogEntryValue.cb_index;
+end
+
+function SQLHandler:exit(code)
+    -- frustrating
+    -- C/C++ API call is counted as one instruction, so Exit does not block
+    ParaGlobal.Exit(code)
+    -- we don't want to go more
+    ParaEngine.Sleep(1);
+end
+
+function SQLHandler:createSqliteWALStoreConfig(rootFolder)
+	NPL.load("(gl)script/ide/commonlib.lua");
+	NPL.load("(gl)script/ide/LuaXML.lua");
+	local config = { 
+		name = "tabledb", 
+		{
+			name = "providers", 
+			{ name = "provider", attr = { name = "sqliteWAL", type = "TableDB.SqliteWALStore", file = "(g1)npl_mod/TableDB/SqliteWALStore.lua" }, "" }
+		},
+		{
+			name = "tables",
+			{ name = "table", attr = { provider = "sqliteWAL", name = "default" } }, 
+		}
+	}
+
+	local config_path = rootFolder .. "/tabledb.config.xml";
+	local str = commonlib.Lua2XmlString(config, true);
+	ParaIO.CreateDirectory(config_path);
+	local file = ParaIO.open(config_path, "w");
+	if (file:IsValid()) then
+		file:WriteString(str);
+		file:close();
+	end
+end
+
+
+
+local started = false;
+local function activate()
+    if(not started and msg and msg.start) then
+        local sqlHandler = SQLHandler:new(msg.baseDir, msg.useFile);
+        sqlHandler:start();
+        started = true;
+    end
+end
+
+NPL.this(activate);

--- a/npl_mod/TableDB/SqliteWALStore.lua
+++ b/npl_mod/TableDB/SqliteWALStore.lua
@@ -9,7 +9,6 @@ NPL.load("(gl)npl_mod/TableDB/SqliteWALStore.lua");
 local SqliteWALStore = commonlib.gettable("TableDB.SqliteWALStore");
 ------------------------------------------------------------
 ]]
-
 NPL.load("(gl)script/ide/commonlib.lua");
 NPL.load("(gl)script/sqlite/sqlite3.lua");
 
@@ -20,15 +19,12 @@ local SqliteWALStore = commonlib.inherit(SqliteStore, commonlib.gettable("TableD
 local cbWALHandlerFile = "(%s)RPC/WALHandler.lua";
 local cb_thread = "rtdb"
 
-local follower_dbs = {}
-
 function SqliteWALStore:ctor()
 end
 
 function SqliteWALStore:init(collection, init_args)
     SqliteWALStore._super.init(self, collection);
     local dbName = self.kFileName
-    -- self.collection = collection;
     self._db:set_wal_page_hook(function(page_data, pgno, nTruncate, isCommit)
         local msg = {
             rootFolder = collection:GetParent():GetRootFolder(),
@@ -41,44 +37,10 @@ function SqliteWALStore:init(collection, init_args)
         
         NPL.activate(self:GetReplyAddress(cb_thread or "main"), msg);
         
-        -- local db2 = follower_dbs[collection:GetName()];
-        -- if not db2 then
-        --   db2 = sqlite3.open(dbName .. "2")
-        --   db2:exec("PRAGMA journal_mode=WAL;");
-        --   db2:exec("PRAGMA synchronous=NORMAL;");
-        --   follower_dbs[collection:GetName()] = db2;
-        -- end
-        -- followers simply append wal, no need to worry about the meta data
-        print(format("wal_page_hook: pgSize %d, pgno %d, nTruncate %d, isCommit %d", #page_data, pgno, nTruncate, isCommit))
-        -- db2:wal_inject_page(page_data, pgno, nTruncate, isCommit)
+        -- print(format("wal_page_hook: pgSize %d, pgno %d, nTruncate %d, isCommit %d", #page_data, pgno, nTruncate, isCommit))
         return 1
     end)
     
-    -- self._db:set_wal_checkpoint_hook(function ()
-    --   print("wal_checkpoint_hook")
-    --   follower_dbs[self.collection:GetName()]:wal_checkpoint("main")
-    --   return 1
-    -- end)
-    -- TODO: we may not need below if we use TableDB
-    -- create meta data in sqliteStore
-    -- self:Begin();
-    -- 	-- drop all tables.
-    -- 	self:DropAllMetaTables();
-    -- 	-- create all tables
-    -- 	self:CreateTables();
-    -- 	-- insert version infos
-    -- 	local insert_stmt = assert(self._db:prepare("INSERT INTO SystemInfo (Name, Value) VALUES(?, ?)"));
-    -- 	insert_stmt:bind("version", SqliteStore.kCurrentVersion);
-    -- 	insert_stmt:exec();
-    -- 	insert_stmt:bind("author", "NPLRuntime");
-    -- 	insert_stmt:exec();
-    -- 	insert_stmt:bind("name", self:GetCollection():GetName());
-    -- 	insert_stmt:exec();
-    -- 	insert_stmt:close();
-    -- self:End();
-    -- self:FlushAll();
-    -- LOG.std(nil, "TableDB", "SqliteWALStore", "%s is recreated for raft", self.kFileName);
-    -- self:ValidateDB();
     return self;
 end
 
@@ -92,9 +54,6 @@ end
 
 function SqliteWALStore:Close()
     SqliteWALStore._super.Close(self)
--- send close
--- follower_dbs[self.collection:GetName()]:close()
--- follower_dbs[self.collection:GetName()] = nil;
 end
 
 

--- a/npl_mod/TableDB/SqliteWALStore.lua
+++ b/npl_mod/TableDB/SqliteWALStore.lua
@@ -46,6 +46,7 @@ end
 
 function SqliteWALStore:injectWALPage(query, callbackFunc)
     self._db:wal_inject_page(query.page_data, query.pgno, query.nTruncate, query.isCommit)
+    -- print(format("injected %d", query.logIndex));
     if (not self.checkpoint_timer:IsEnabled()) then
         self.checkpoint_timer:Change(self.AutoCheckPointInterval, self.AutoCheckPointInterval);
     end

--- a/npl_mod/TableDB/SqliteWALStore.lua
+++ b/npl_mod/TableDB/SqliteWALStore.lua
@@ -1,0 +1,103 @@
+--[[
+Title: base class for store
+Author(s): liuluheng,
+Date: 2017/7/31
+Desc:
+use the lib:
+------------------------------------------------------------
+NPL.load("(gl)npl_mod/TableDB/SqliteWALStore.lua");
+local SqliteWALStore = commonlib.gettable("TableDB.SqliteWALStore");
+------------------------------------------------------------
+]]
+
+NPL.load("(gl)script/ide/commonlib.lua");
+NPL.load("(gl)script/sqlite/sqlite3.lua");
+
+NPL.load("(gl)script/ide/System/Database/SqliteStore.lua");
+local SqliteStore = commonlib.gettable("System.Database.SqliteStore");
+local SqliteWALStore = commonlib.inherit(SqliteStore, commonlib.gettable("TableDB.SqliteWALStore"));
+
+local cbWALHandlerFile = "(%s)RPC/WALHandler.lua";
+local cb_thread = "rtdb"
+
+local follower_dbs = {}
+
+function SqliteWALStore:ctor()
+end
+
+function SqliteWALStore:init(collection, init_args)
+    SqliteWALStore._super.init(self, collection);
+    local dbName = self.kFileName
+    -- self.collection = collection;
+    self._db:set_wal_page_hook(function(page_data, pgno, nTruncate, isCommit)
+        local msg = {
+            rootFolder = collection:GetParent():GetRootFolder(),
+            collectionName = collection:GetName(),
+            page_data = page_data,
+            pgno = pgno,
+            nTruncate = nTruncate,
+            isCommit = isCommit,
+        }
+        
+        NPL.activate(self:GetReplyAddress(cb_thread or "main"), msg);
+        
+        -- local db2 = follower_dbs[collection:GetName()];
+        -- if not db2 then
+        --   db2 = sqlite3.open(dbName .. "2")
+        --   db2:exec("PRAGMA journal_mode=WAL;");
+        --   db2:exec("PRAGMA synchronous=NORMAL;");
+        --   follower_dbs[collection:GetName()] = db2;
+        -- end
+        -- followers simply append wal, no need to worry about the meta data
+        print(format("wal_page_hook: pgSize %d, pgno %d, nTruncate %d, isCommit %d", #page_data, pgno, nTruncate, isCommit))
+        -- db2:wal_inject_page(page_data, pgno, nTruncate, isCommit)
+        return 1
+    end)
+    
+    -- self._db:set_wal_checkpoint_hook(function ()
+    --   print("wal_checkpoint_hook")
+    --   follower_dbs[self.collection:GetName()]:wal_checkpoint("main")
+    --   return 1
+    -- end)
+    -- TODO: we may not need below if we use TableDB
+    -- create meta data in sqliteStore
+    -- self:Begin();
+    -- 	-- drop all tables.
+    -- 	self:DropAllMetaTables();
+    -- 	-- create all tables
+    -- 	self:CreateTables();
+    -- 	-- insert version infos
+    -- 	local insert_stmt = assert(self._db:prepare("INSERT INTO SystemInfo (Name, Value) VALUES(?, ?)"));
+    -- 	insert_stmt:bind("version", SqliteStore.kCurrentVersion);
+    -- 	insert_stmt:exec();
+    -- 	insert_stmt:bind("author", "NPLRuntime");
+    -- 	insert_stmt:exec();
+    -- 	insert_stmt:bind("name", self:GetCollection():GetName());
+    -- 	insert_stmt:exec();
+    -- 	insert_stmt:close();
+    -- self:End();
+    -- self:FlushAll();
+    -- LOG.std(nil, "TableDB", "SqliteWALStore", "%s is recreated for raft", self.kFileName);
+    -- self:ValidateDB();
+    return self;
+end
+
+function SqliteWALStore:injectWALPage(query, callbackFunc)
+    self._db:wal_inject_page(query.page_data, query.pgno, query.nTruncate, query.isCommit)
+    if (not self.checkpoint_timer:IsEnabled()) then
+        self.checkpoint_timer:Change(self.AutoCheckPointInterval, self.AutoCheckPointInterval);
+    end
+end
+
+
+function SqliteWALStore:Close()
+    SqliteWALStore._super.Close(self)
+-- send close
+-- follower_dbs[self.collection:GetName()]:close()
+-- follower_dbs[self.collection:GetName()] = nil;
+end
+
+
+function SqliteWALStore:GetReplyAddress(cb_thread)
+    return format(cbWALHandlerFile, cb_thread);
+end

--- a/npl_mod/TableDB/SqliteWALStore.lua
+++ b/npl_mod/TableDB/SqliteWALStore.lua
@@ -17,7 +17,7 @@ local SqliteStore = commonlib.gettable("System.Database.SqliteStore");
 local SqliteWALStore = commonlib.inherit(SqliteStore, commonlib.gettable("TableDB.SqliteWALStore"));
 
 local cbWALHandlerFile = "(%s)RPC/WALHandler.lua";
-local cb_thread = "rtdb"
+local cb_thread = "raft"
 
 function SqliteWALStore:ctor()
 end

--- a/npl_mod/TableDB/SqliteWALStore.lua
+++ b/npl_mod/TableDB/SqliteWALStore.lua
@@ -50,7 +50,7 @@ end
 function SqliteWALStore:injectWALPage(query, callbackFunc)
     local r = self._db:wal_inject_page(query.page_data, query.pgno, query.nTruncate, query.isCommit)
     if r ~= 0 then
-      self.logger.error("%d inject failed", query.logIndex);
+      self.logger.error("%d inject failed, %d", query.logIndex, r);
     else
       self.logger.trace("injected %d", query.logIndex);
     end

--- a/npl_mod/TableDB/test/test_TableDatabase.lua
+++ b/npl_mod/TableDB/test/test_TableDatabase.lua
@@ -69,7 +69,7 @@ function TestSQLOperations()
 	db.User:find({ ["+name"] = {"1", limit=2} }, function(err, rows) assert(#rows==2); end);
 	-- return at most 1 row whose id is greater than -1
 	db.User:find({ _id = { gt = -1, limit = 1, skip == 1} }, function(err, rows) assert(#rows==1); echo("all tests succeed!") end);
-	db.User:close();
+	-- db.User:close();
 end
 
 
@@ -105,7 +105,7 @@ function TestInsertThroughputNoIndex()
 		npl_profiler.perf_end("tableDB_BlockingAPILatency", true)
 		log(commonlib.serialize(npl_profiler.perf_get(), true));			
 	end);
-	db.insertNoIndex:close();
+	-- db.insertNoIndex:close();
 end
 
 function TestPerformance()

--- a/npl_mod/TableDBApp/App.lua
+++ b/npl_mod/TableDBApp/App.lua
@@ -8,7 +8,7 @@ Desc:
 NPL.load("(gl)script/ide/commonlib.lua");
 NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
 NPL.load("(gl)npl_mod/Raft/ServerState.lua");
-NPL.load("(gl)npl_mod/Raft/ServerStateManager.lua");
+NPL.load("(gl)npl_mod/Raft/FileBasedServerStateManager.lua");
 NPL.load("(gl)npl_mod/Raft/RaftParameters.lua");
 NPL.load("(gl)npl_mod/Raft/RaftContext.lua");
 NPL.load("(gl)npl_mod/Raft/RpcListener.lua");
@@ -23,7 +23,7 @@ NPL.load("(gl)npl_mod/TableDB/RaftTableDBStateMachine.lua");
 local RaftTableDBStateMachine = commonlib.gettable("TableDB.RaftTableDBStateMachine");
 local ClusterServer = commonlib.gettable("Raft.ClusterServer");
 local RaftClient = commonlib.gettable("Raft.RaftClient");
-local ServerStateManager = commonlib.gettable("Raft.ServerStateManager");
+local FileBasedServerStateManager = commonlib.gettable("Raft.FileBasedServerStateManager");
 local RaftParameters = commonlib.gettable("Raft.RaftParameters");
 local RaftContext = commonlib.gettable("Raft.RaftContext");
 local RpcListener = commonlib.gettable("Raft.RpcListener");
@@ -50,7 +50,7 @@ end
 
 logger.info("app arg:"..baseDir..mpPort..raftMode)
 
-local stateManager = ServerStateManager:new(baseDir);
+local stateManager = FileBasedServerStateManager:new(baseDir);
 local config = stateManager:loadClusterConfiguration();
 
 logger.info("config:%s", util.table_tostring(config))

--- a/npl_mod/TableDBApp/App.lua
+++ b/npl_mod/TableDBApp/App.lua
@@ -65,7 +65,7 @@ end
 local sqlHandlerFile = format("(%s)npl_mod/TableDB/SQLHandler.lua", threadName);
 NPL.activate(sqlHandlerFile, {start = true, baseDir = baseDir, useFile = true});
 
-logger.info("app arg:"..baseDir..mpPort..raftMode)
+logger.info("app arg:"..baseDir.. " " ..raftMode)
 
 local stateManager = ServerStateManager:new(baseDir);
 local config = stateManager:loadClusterConfiguration();
@@ -113,10 +113,10 @@ local function executeAsClient()
 
     if clientMode == "appendEntries" then
       NPL.load("(gl)npl_mod/TableDB/test/test_TableDatabase.lua");
-      TestSQLOperations();
+      -- TestSQLOperations();
       -- TestInsertThroughputNoIndex()
       -- TestPerformance()
-      -- TestBulkOperations()
+      TestBulkOperations()
       -- TestTimeout()
       -- TestBlockingAPI()
       -- TestBlockingAPILatency()

--- a/npl_mod/TableDBApp/App.lua
+++ b/npl_mod/TableDBApp/App.lua
@@ -37,7 +37,7 @@ local logger = LoggerFactory.getLogger("App")
 
 local threadName = ParaEngine.GetAppCommandLineByParam("threadName", "main");
 local baseDir = ParaEngine.GetAppCommandLineByParam("baseDir", "");
-local mpPort = ParaEngine.GetAppCommandLineByParam("mpPort", "8090");
+-- local mpPort = ParaEngine.GetAppCommandLineByParam("mpPort", "8090");
 local raftMode = ParaEngine.GetAppCommandLineByParam("raftMode", "server");
 local clientMode = ParaEngine.GetAppCommandLineByParam("clientMode", "appendEntries");
 local serverId = tonumber(ParaEngine.GetAppCommandLineByParam("serverId", "5"));
@@ -46,7 +46,7 @@ if threadName ~= "main" then
     NPL.CreateRuntimeState(threadName, 0):Start();
 end
 
-logger.info("app arg:"..baseDir..mpPort..raftMode)
+logger.info("app arg:"..baseDir.." "..raftMode)
 
 local stateManager = ServerStateManager:new(baseDir);
 local config = stateManager:loadClusterConfiguration();

--- a/npl_mod/TableDBApp/App.lua
+++ b/npl_mod/TableDBApp/App.lua
@@ -9,6 +9,7 @@ NPL.load("(gl)script/ide/commonlib.lua");
 NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
 NPL.load("(gl)npl_mod/Raft/ServerState.lua");
 NPL.load("(gl)npl_mod/Raft/FileBasedServerStateManager.lua");
+-- NPL.load("(gl)npl_mod/Raft/SqliteBasedServerStateManager.lua");
 NPL.load("(gl)npl_mod/Raft/RaftParameters.lua");
 NPL.load("(gl)npl_mod/Raft/RaftContext.lua");
 NPL.load("(gl)npl_mod/Raft/RpcListener.lua");
@@ -24,6 +25,7 @@ local RaftTableDBStateMachine = commonlib.gettable("TableDB.RaftTableDBStateMach
 local ClusterServer = commonlib.gettable("Raft.ClusterServer");
 local RaftClient = commonlib.gettable("Raft.RaftClient");
 local FileBasedServerStateManager = commonlib.gettable("Raft.FileBasedServerStateManager");
+-- local SqliteBasedServerStateManager = commonlib.gettable("Raft.SqliteBasedServerStateManager");
 local RaftParameters = commonlib.gettable("Raft.RaftParameters");
 local RaftContext = commonlib.gettable("Raft.RaftContext");
 local RpcListener = commonlib.gettable("Raft.RpcListener");
@@ -50,7 +52,8 @@ end
 
 logger.info("app arg:"..baseDir..mpPort..raftMode)
 
-local stateManager = FileBasedServerStateManager:new(baseDir);
+local ServerStateManager = FileBasedServerStateManager;
+local stateManager = ServerStateManager:new(baseDir);
 local config = stateManager:loadClusterConfiguration();
 
 logger.info("config:%s", util.table_tostring(config))

--- a/npl_mod/TableDBApp/App.lua
+++ b/npl_mod/TableDBApp/App.lua
@@ -117,7 +117,15 @@ local function executeAsClient()
     else
       NPL.load("(gl)npl_mod/TableDB/RaftSqliteStore.lua");
       local RaftSqliteStore = commonlib.gettable("TableDB.RaftSqliteStore");
-      RaftSqliteStore:createRaftClient()
+      local param = {
+        baseDir = "./",
+        host = "localhost",
+        port = "9004",
+        id = "server4:",
+        threadName = "rtdb",
+        rootFolder = "temp/test_raft_database",
+      }
+      RaftSqliteStore:createRaftClient(param.baseDir, param.host, param.port, param.id, param.threadName, param.rootFolder);
       local raftClient = RaftSqliteStore:getRaftClient();
 
       if clientMode == "addServer" then

--- a/npl_mod/TableDBApp/App.lua
+++ b/npl_mod/TableDBApp/App.lua
@@ -8,8 +8,9 @@ Desc:
 NPL.load("(gl)script/ide/commonlib.lua");
 NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
 NPL.load("(gl)npl_mod/Raft/ServerState.lua");
-NPL.load("(gl)npl_mod/Raft/FileBasedServerStateManager.lua");
--- NPL.load("(gl)npl_mod/Raft/SqliteBasedServerStateManager.lua");
+
+
+
 NPL.load("(gl)npl_mod/Raft/RaftParameters.lua");
 NPL.load("(gl)npl_mod/Raft/RaftContext.lua");
 NPL.load("(gl)npl_mod/Raft/RpcListener.lua");
@@ -23,8 +24,6 @@ NPL.load("(gl)npl_mod/TableDB/RaftTableDBStateMachine.lua");
 local RaftTableDBStateMachine = commonlib.gettable("TableDB.RaftTableDBStateMachine");
 local ClusterServer = commonlib.gettable("Raft.ClusterServer");
 local RaftClient = commonlib.gettable("Raft.RaftClient");
-local FileBasedServerStateManager = commonlib.gettable("Raft.FileBasedServerStateManager");
--- local SqliteBasedServerStateManager = commonlib.gettable("Raft.SqliteBasedServerStateManager");
 local RaftParameters = commonlib.gettable("Raft.RaftParameters");
 local RaftContext = commonlib.gettable("Raft.RaftContext");
 local RpcListener = commonlib.gettable("Raft.RpcListener");
@@ -48,9 +47,26 @@ if threadName ~= "main" then
     NPL.CreateRuntimeState(threadName, 0):Start();
 end
 
-logger.info("app arg:"..baseDir.." "..raftMode)
+local raftThreadName = "raft"
+NPL.CreateRuntimeState(raftThreadName, 0):Start();
 
-local ServerStateManager = FileBasedServerStateManager;
+local useFileStateManager = true;
+local ServerStateManager;
+if useFileStateManager then
+  NPL.load("(gl)npl_mod/Raft/FileBasedServerStateManager.lua");
+  local FileBasedServerStateManager = commonlib.gettable("Raft.FileBasedServerStateManager");
+  ServerStateManager = FileBasedServerStateManager;
+else
+  NPL.load("(gl)npl_mod/Raft/SqliteBasedServerStateManager.lua");
+  local SqliteBasedServerStateManager = commonlib.gettable("Raft.SqliteBasedServerStateManager");
+  ServerStateManager = SqliteBasedServerStateManager;
+end
+
+local sqlHandlerFile = format("(%s)npl_mod/TableDB/SQLHandler.lua", threadName);
+NPL.activate(sqlHandlerFile, {start = true, baseDir = baseDir, useFile = true});
+
+logger.info("app arg:"..baseDir..mpPort..raftMode)
+
 local stateManager = ServerStateManager:new(baseDir);
 local config = stateManager:loadClusterConfiguration();
 
@@ -83,7 +99,7 @@ local function executeInServerMode(stateMachine)
     raftParameters.snapshotDistance = 5000;
     raftParameters.snapshotBlockSize = 0;
 
-    local rpcListener = RpcListener:new(parsed_url.host, parsed_url.port, thisServer.id, config.servers, threadName)
+    local rpcListener = RpcListener:new(parsed_url.host, parsed_url.port, thisServer.id, config.servers, raftThreadName)
     local context = RaftContext:new(stateManager,
                                     stateMachine,
                                     raftParameters,
@@ -97,10 +113,10 @@ local function executeAsClient()
 
     if clientMode == "appendEntries" then
       NPL.load("(gl)npl_mod/TableDB/test/test_TableDatabase.lua");
-      -- TestSQLOperations();
+      TestSQLOperations();
       -- TestInsertThroughputNoIndex()
       -- TestPerformance()
-      TestBulkOperations()
+      -- TestBulkOperations()
       -- TestTimeout()
       -- TestBlockingAPI()
       -- TestBlockingAPILatency()
@@ -124,8 +140,9 @@ local function executeAsClient()
         id = "server4:",
         threadName = "rtdb",
         rootFolder = "temp/test_raft_database",
+        useFile = useFileStateManager,
       }
-      RaftSqliteStore:createRaftClient(param.baseDir, param.host, param.port, param.id, param.threadName, param.rootFolder);
+      RaftSqliteStore:createRaftClient(param.baseDir, param.host, param.port, param.id, param.threadName, param.rootFolder, param.useFile);
       local raftClient = RaftSqliteStore:getRaftClient();
 
       if clientMode == "addServer" then
@@ -151,7 +168,7 @@ local function executeAsClient()
     end
 end
 
-local vfileID = format("(%s)npl_mod/TableDBApp/App.lua", threadName);
+local vfileID = format("(%s)npl_mod/TableDBApp/App.lua", raftThreadName);
 NPL.activate(vfileID, {start = true});
 
 
@@ -161,7 +178,7 @@ local function activate()
     started = true;
     -- raft stateMachine
     logger.info("start stateMachine");
-    local rtdb = RaftTableDBStateMachine:new(baseDir, parsed_url.host, mpPort, threadName)
+    local rtdb = RaftTableDBStateMachine:new(baseDir, parsed_url.host, mpPort, raftThreadName)
     if raftMode:lower() == "server" then
       -- executeInServerMode(mp)
       executeInServerMode(rtdb)

--- a/npl_mod/TableDBApp/App.lua
+++ b/npl_mod/TableDBApp/App.lua
@@ -119,7 +119,15 @@ local function executeAsClient()
     else
       NPL.load("(gl)npl_mod/TableDB/RaftSqliteStore.lua");
       local RaftSqliteStore = commonlib.gettable("TableDB.RaftSqliteStore");
-      RaftSqliteStore:createRaftClient()
+      local param = {
+        baseDir = "./",
+        host = "localhost",
+        port = "9004",
+        id = "server4:",
+        threadName = "rtdb",
+        rootFolder = "temp/test_raft_database",
+      }
+      RaftSqliteStore:createRaftClient(param.baseDir, param.host, param.port, param.id, param.threadName, param.rootFolder);
       local raftClient = RaftSqliteStore:getRaftClient();
 
       if clientMode == "addServer" then

--- a/npl_mod/TableDBApp/App.lua
+++ b/npl_mod/TableDBApp/App.lua
@@ -8,7 +8,7 @@ Desc:
 NPL.load("(gl)script/ide/commonlib.lua");
 NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
 NPL.load("(gl)npl_mod/Raft/ServerState.lua");
-NPL.load("(gl)npl_mod/Raft/ServerStateManager.lua");
+NPL.load("(gl)npl_mod/Raft/FileBasedServerStateManager.lua");
 NPL.load("(gl)npl_mod/Raft/RaftParameters.lua");
 NPL.load("(gl)npl_mod/Raft/RaftContext.lua");
 NPL.load("(gl)npl_mod/Raft/RpcListener.lua");
@@ -22,7 +22,7 @@ NPL.load("(gl)npl_mod/TableDB/RaftTableDBStateMachine.lua");
 local RaftTableDBStateMachine = commonlib.gettable("TableDB.RaftTableDBStateMachine");
 local ClusterServer = commonlib.gettable("Raft.ClusterServer");
 local RaftClient = commonlib.gettable("Raft.RaftClient");
-local ServerStateManager = commonlib.gettable("Raft.ServerStateManager");
+local FileBasedServerStateManager = commonlib.gettable("Raft.FileBasedServerStateManager");
 local RaftParameters = commonlib.gettable("Raft.RaftParameters");
 local RaftContext = commonlib.gettable("Raft.RaftContext");
 local RpcListener = commonlib.gettable("Raft.RpcListener");
@@ -48,7 +48,7 @@ end
 
 logger.info("app arg:"..baseDir.." "..raftMode)
 
-local stateManager = ServerStateManager:new(baseDir);
+local stateManager = FileBasedServerStateManager:new(baseDir);
 local config = stateManager:loadClusterConfiguration();
 
 logger.info("config:%s", util.table_tostring(config))

--- a/npl_mod/TableDBApp/App.lua
+++ b/npl_mod/TableDBApp/App.lua
@@ -40,7 +40,7 @@ local logger = LoggerFactory.getLogger("App")
 
 local threadName = ParaEngine.GetAppCommandLineByParam("threadName", "main");
 local baseDir = ParaEngine.GetAppCommandLineByParam("baseDir", "");
-local mpPort = ParaEngine.GetAppCommandLineByParam("mpPort", "8090");
+-- local mpPort = ParaEngine.GetAppCommandLineByParam("mpPort", "8090");
 local raftMode = ParaEngine.GetAppCommandLineByParam("raftMode", "server");
 local clientMode = ParaEngine.GetAppCommandLineByParam("clientMode", "appendEntries");
 local serverId = tonumber(ParaEngine.GetAppCommandLineByParam("serverId", "5"));
@@ -67,7 +67,7 @@ end
 local sqlHandlerFile = format("(%s)npl_mod/TableDB/SQLHandler.lua", threadName);
 NPL.activate(sqlHandlerFile, {start = true, baseDir = baseDir, useFile = true});
 
-logger.info("app arg:"..baseDir..mpPort..raftMode)
+logger.info("app arg:"..baseDir.. " " ..raftMode)
 
 local stateManager = ServerStateManager:new(baseDir);
 local config = stateManager:loadClusterConfiguration();
@@ -115,10 +115,10 @@ local function executeAsClient()
 
     if clientMode == "appendEntries" then
       NPL.load("(gl)npl_mod/TableDB/test/test_TableDatabase.lua");
-      TestSQLOperations();
+      -- TestSQLOperations();
       -- TestInsertThroughputNoIndex()
       -- TestPerformance()
-      -- TestBulkOperations()
+      TestBulkOperations()
       -- TestTimeout()
       -- TestBlockingAPI()
       -- TestBlockingAPILatency()

--- a/npl_mod/TableDBApp/App.lua
+++ b/npl_mod/TableDBApp/App.lua
@@ -16,7 +16,6 @@ NPL.load("(gl)npl_mod/TableDBApp/MessagePrinter.lua");
 NPL.load("(gl)npl_mod/Raft/RaftClient.lua");
 NPL.load("(gl)script/ide/socket/url.lua");
 NPL.load("(gl)npl_mod/Raft/RaftConsensus.lua");
-NPL.load("(gl)npl_mod/Raft/RpcClient.lua");
 NPL.load("(gl)npl_mod/Raft/ClusterServer.lua");
 NPL.load("(gl)npl_mod/TableDB/RaftTableDBStateMachine.lua");
 
@@ -29,7 +28,6 @@ local RaftContext = commonlib.gettable("Raft.RaftContext");
 local RpcListener = commonlib.gettable("Raft.RpcListener");
 local url = commonlib.gettable("commonlib.socket.url")
 local RaftConsensus = commonlib.gettable("Raft.RaftConsensus");
-local RpcClient = commonlib.gettable("Raft.RpcClient");
 local MessagePrinter = commonlib.gettable("TableDBApp.MessagePrinter");
 local util = commonlib.gettable("System.Compiler.lib.util")
 local LoggerFactory = NPL.load("(gl)npl_mod/Raft/LoggerFactory.lua");

--- a/npl_mod/TableDBApp/App.lua
+++ b/npl_mod/TableDBApp/App.lua
@@ -9,6 +9,7 @@ NPL.load("(gl)script/ide/commonlib.lua");
 NPL.load("(gl)script/ide/System/Compiler/lib/util.lua");
 NPL.load("(gl)npl_mod/Raft/ServerState.lua");
 NPL.load("(gl)npl_mod/Raft/FileBasedServerStateManager.lua");
+-- NPL.load("(gl)npl_mod/Raft/SqliteBasedServerStateManager.lua");
 NPL.load("(gl)npl_mod/Raft/RaftParameters.lua");
 NPL.load("(gl)npl_mod/Raft/RaftContext.lua");
 NPL.load("(gl)npl_mod/Raft/RpcListener.lua");
@@ -23,6 +24,7 @@ local RaftTableDBStateMachine = commonlib.gettable("TableDB.RaftTableDBStateMach
 local ClusterServer = commonlib.gettable("Raft.ClusterServer");
 local RaftClient = commonlib.gettable("Raft.RaftClient");
 local FileBasedServerStateManager = commonlib.gettable("Raft.FileBasedServerStateManager");
+-- local SqliteBasedServerStateManager = commonlib.gettable("Raft.SqliteBasedServerStateManager");
 local RaftParameters = commonlib.gettable("Raft.RaftParameters");
 local RaftContext = commonlib.gettable("Raft.RaftContext");
 local RpcListener = commonlib.gettable("Raft.RpcListener");
@@ -48,7 +50,8 @@ end
 
 logger.info("app arg:"..baseDir.." "..raftMode)
 
-local stateManager = FileBasedServerStateManager:new(baseDir);
+local ServerStateManager = FileBasedServerStateManager;
+local stateManager = ServerStateManager:new(baseDir);
 local config = stateManager:loadClusterConfiguration();
 
 logger.info("config:%s", util.table_tostring(config))

--- a/setup/addsrv.bat
+++ b/setup/addsrv.bat
@@ -13,7 +13,7 @@ if exist "%curdir%\server%1" (
 mkdir "%curdir%\server%1"
 echo server.id=%1 > "%curdir%\server%1\config.properties"
 echo {"logIndex":0,"lastLogIndex":0,"servers":[{"id": %1,"endpoint": "tcp://localhost:900%1"}]}> "%curdir%\server%1\cluster.json"
-start "server%1" /D "%curdir%\server%1" npl -d bootstrapper="npl_mod/TableDBApp/App.lua" servermode="true" dev="../../" raftMode="server" baseDir="" mpPort="800%1"
+start "server%1" /D "%curdir%\server%1" npl -d bootstrapper="npl_mod/TableDBApp/App.lua" servermode="true" dev="../../" raftMode="server" baseDir="" threadName="rtdb" mpPort="800%1"
 @echo on
 
 :exit

--- a/setup/setup.bat
+++ b/setup/setup.bat
@@ -9,7 +9,7 @@ for %%i in (1 2 3) do (
     copy /Y init-cluster.json "%curdir%\server%%i\cluster.json"
     echo server.id=%%i> "%curdir%\server%%i\config.properties"
     echo start server%%i
-    start "server%%i" /D "%curdir%\server%%i" npl -d bootstrapper="npl_mod/TableDBApp/App.lua" servermode="true" dev="../../" raftMode="server" threadName="rtdb" baseDir="" mpPort="800%%i"
+    start "server%%i" /D "%curdir%\server%%i" npl -d bootstrapper="npl_mod/TableDBApp/App.lua" servermode="true" dev="../../" raftMode="server" threadName="rtdb" baseDir="" REM mpPort="800%%i"
 )
 
 goto done

--- a/setup/setup.bat
+++ b/setup/setup.bat
@@ -9,7 +9,7 @@ for %%i in (1 2 3) do (
     copy /Y init-cluster.json "%curdir%\server%%i\cluster.json"
     echo server.id=%%i> "%curdir%\server%%i\config.properties"
     echo start server%%i
-    start "server%%i" /D "%curdir%\server%%i" npl -d bootstrapper="npl_mod/TableDBApp/App.lua" servermode="true" dev="../../" raftMode="server" threadName="rtdb" baseDir="" REM mpPort="800%%i"
+    start "server%%i" /D "%curdir%\server%%i" npl -d bootstrapper="npl_mod/TableDBApp/App.lua" servermode="true" dev="../../" raftMode="server" threadName="rtdb" baseDir="./"
 )
 
 goto done
@@ -18,7 +18,7 @@ echo start a client
 mkdir client
 copy /Y init-cluster.json "%curdir%\client\cluster.json"
 copy /Y "%curdir%\server1\config.properties" "%curdir%\client\config.properties"
-start "client" /D "%curdir%\client" npl -d bootstrapper="npl_mod/TableDBApp/App.lua" servermode="true" dev="../../" raftMode="client" baseDir="" clientMode="%2" serverId="%3"
+start "client" /D "%curdir%\client" npl -d bootstrapper="npl_mod/TableDBApp/App.lua" servermode="true" dev="../../" raftMode="client" baseDir="./" clientMode="%2" serverId="%3"
 
 
 goto done

--- a/setup/setup.bat
+++ b/setup/setup.bat
@@ -9,7 +9,7 @@ for %%i in (1 2 3) do (
     copy /Y init-cluster.json "%curdir%\server%%i\cluster.json"
     echo server.id=%%i> "%curdir%\server%%i\config.properties"
     echo start server%%i
-    start "server%%i" /D "%curdir%\server%%i" npl -d bootstrapper="npl_mod/TableDBApp/App.lua" servermode="true" dev="../../" raftMode="server" threadName="rtdb" baseDir="" mpPort="800%%i"
+    start "server%%i" /D "%curdir%\server%%i" npl -d bootstrapper="npl_mod/TableDBApp/App.lua" servermode="true" dev="../../" raftMode="server" threadName="rtdb" baseDir="./"
 )
 
 goto done
@@ -18,7 +18,7 @@ echo start a client
 mkdir client
 copy /Y init-cluster.json "%curdir%\client\cluster.json"
 copy /Y "%curdir%\server1\config.properties" "%curdir%\client\config.properties"
-start "client" /D "%curdir%\client" npl -d bootstrapper="npl_mod/TableDBApp/App.lua" servermode="true" dev="../../" raftMode="client" baseDir="" clientMode="%2" serverId="%3"
+start "client" /D "%curdir%\client" npl -d bootstrapper="npl_mod/TableDBApp/App.lua" servermode="true" dev="../../" raftMode="client" baseDir="./" clientMode="%2" serverId="%3"
 
 
 goto done


### PR DESCRIPTION
This PR add `SQLHandler`, `SqliteWALStore`, `WALSequentialLogStore` and various others to **make sqlite WAL Raft Log.** Like `actordb`, It implements
 > the leader executes the SQL, but the followers just append to WAL. 

The follower's db is the same with leader's and can be checked with `diff`.

**Throuput improves significantly,**

1. WAL act like a batch of updates.
2. we separate the SQLHandler to another thread.

Now the implementation contains 3 threads: 
1. `rtdb` recv TableDB operations and excecute "SQL".
2. `raft` the core raft logic.
3. `tdb` main io thread.